### PR TITLE
WebSocket API ref: remove `row_pk`.

### DIFF
--- a/docs/ws/index.md
+++ b/docs/ws/index.md
@@ -175,7 +175,6 @@ message TableRowOperation {
         INSERT = 1;
     }
     OperationType op = 1;
-    bytes row_pk = 2;
     bytes row = 3;
 }
 ```
@@ -189,9 +188,8 @@ Each `SubscriptionUpdate` contains a `TableUpdate` for each table with subscribe
 | `tableRowOperations` | A `TableRowOperation` for each inserted or deleted row.                                                       |
 
 | `TableRowOperation` field | Value                                                                                                                                                                                                      |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `op`                      | `INSERT` for inserted rows during a [`TransactionUpdate`](#transactionupdate) or rows resident upon applying a subscription; `DELETE` for deleted rows during a [`TransactionUpdate`](#transactionupdate). |
-| `row_pk`                  | An opaque hash of the row computed by SpacetimeDB. Clients can use this hash to identify a previously `INSERT`ed row during a `DELETE`.                                                                    |
 | `row`                     | The altered row, encoded as a BSATN `ProductValue`.                                                                                                                                                        |
 
 ##### Text: JSON encoding
@@ -214,7 +212,6 @@ Each `SubscriptionUpdate` contains a `TableUpdate` for each table with subscribe
 // TableRowOperation:
 {
     "op": "insert" | "delete",
-    "row_pk": string,
     "row": array
 }
 ```
@@ -228,9 +225,8 @@ Each `SubscriptionUpdate` contains a `TableUpdate` for each table with subscribe
 | `table_row_operations` | A `TableRowOperation` for each inserted or deleted row.                                                        |
 
 | `TableRowOperation` field | Value                                                                                                                                                                                                          |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `op`                      | `"insert"` for inserted rows during a [`TransactionUpdate`](#transactionupdate) or rows resident upon applying a subscription; `"delete"` for deleted rows during a [`TransactionUpdate`](#transactionupdate). |
-| `row_pk`                  | An opaque hash of the row computed by SpacetimeDB. Clients can use this hash to identify a previously inserted row during a delete.                                                                            |
 | `row`                     | The altered row, encoded as a JSON array.                                                                                                                                                                      |
 
 #### `TransactionUpdate`


### PR DESCRIPTION
Re https://github.com/clockworklabs/SpacetimeDB/pull/840 .

We're removing the `row_pk` from the WebSocket API `TableRowOperation`, as computing it has a major performance impact on the server.

This commit removes references to it from the WebSocket API reference.