### PR TITLE
Explicitly remind the reader to start the server

### DIFF
--- a/docs/modules/c-sharp/quickstart.md
+++ b/docs/modules/c-sharp/quickstart.md
@@ -257,6 +257,10 @@ public static void OnDisconnect(DbEventArgs dbEventArgs)
 }
 ```
 
+## Start the Server
+
+If you haven't already started the SpacetimeDB server, run the `spacetime start` command in a _separate_ terminal and leave it running while you continue following along.
+
 ## Publish the module
 
 And that's all of our module code! We'll run `spacetime publish` to compile our module and publish it on SpacetimeDB. `spacetime publish` takes an optional name which will map to the database's unique address. Clients can connect either by name or by address, but names are much more pleasant. Come up with a unique name, and fill it in where we've written `<module-name>`.


### PR DESCRIPTION
When I initially read this doc, I assumed `spacetime publish ...` would automatically start a server for me if one wasn't running, and I had to dive through the tech support channel on Discord to find a message from someone else who had already experienced this same problem.

This makes it clear that the reader must actually start the server themself.