### PR TITLE
Switches to a canonical GitHub slugger format so that our slugs always match links generated on GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "This repository contains the markdown files which are used to display documentation on our [website](https://spacetimedb.com/docs).",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "github-slugger": "^2.0.0"
+  },
   "devDependencies": {
     "@types/node": "^22.10.2",
     "tsx": "^4.19.2",

--- a/scripts/checkLinks.ts
+++ b/scripts/checkLinks.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import nav from '../nav'; // Import the nav object directly
+import GitHubSlugger from 'github-slugger';
 
 // Function to map slugs to file paths from nav.ts
 function extractSlugToPathMap(nav: { items: any[] }): Map<string, string> {
@@ -76,12 +77,10 @@ function extractHeadingsFromMarkdown(filePath: string): string[] {
   const headings: string[] = [];
   let match: RegExpExecArray | null;
 
+  const slugger = new GitHubSlugger();
   while ((match = headingRegex.exec(fileContent)) !== null) {
     const heading = match[2].trim(); // Extract the heading text
-    const slug = heading
-      .toLowerCase()
-      .replace(/[^\w\- ]+/g, '') // Remove special characters
-      .replace(/\s+/g, '-'); // Replace spaces with hyphens
+    const slug = slugger.slug(heading); // Slugify the heading text
     headings.push(slug);
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,11 @@ get-tsconfig@^4.7.5:
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
+
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"


### PR DESCRIPTION
Does what it says on the tin. Notably, this does not change how any actual headers in our docs were being sluggified, although in certain cases it could have changed it.

# Testing

I've verified that the slugs actually work both on GitHub and in the website if we use this method.