### PR TITLE
Fix missing tick marks in Rust quickstart

### DIFF
--- a/docs/sdks/rust/quickstart.md
+++ b/docs/sdks/rust/quickstart.md
@@ -290,6 +290,7 @@ fn print_message(ctx: &EventContext, message: &Message) {
         .unwrap_or_else(|| "unknown".to_string());
     println!("{}: {}", sender, message.text);
 }
+```
 
 ### Print past messages in order
 


### PR DESCRIPTION
One liner, I've tested it.