### PR TITLE
Rekhoff/unity blackhol.io tutorial switcher

### DIFF
--- a/docs/unity/index.md
+++ b/docs/unity/index.md
@@ -2,26 +2,26 @@
 
 Need help with the tutorial or CLI commands? [Join our Discord server](https://discord.gg/spacetimedb)!
 
-In this tutorial you'll learn how to build a small-scoped MMORPG in Unity, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquanted with all the features and best practices of SpacetimeDB, while building a fun little game.
+In this tutorial you'll learn how to build a small-scoped MMORPG in Unity, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquanted with all the features and best practices of SpacetimeDB, while building [a fun little game](https://github.com/ClockworkLabs/Blackholio).
 
 By the end, you should have a basic understanding of what SpacetimeDB offers for developers making multiplayer games. 
 
 The game is inspired by [agar.io](https://agar.io), but SpacetimeDB themed with some fun twists. If you're not familiar [agar.io](https://agar.io), it's a web game in which you and hundreds of other players compete to cultivate mass to become the largest cell in the Petri dish.
 
-Our game, called Blackhol.io, will be similar but with space themes in twists. It should give you a great idea of the types of games you can develop with SpacetimeDB.
+Our game, called [Blackhol.io](https://github.com/ClockworkLabs/Blackholio), will be similar but space themed. It should give you a great idea of the types of games you can develop easily with SpacetimeDB.
 
-This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and coding. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
+This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and programming. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
 
-The SpacetimeDB Unity SDK minimum supported Unity version is `2021.2` as the SDK requires C# 9. This tutorial has been tested with the following Unity versions.
+We recommend using Unity `2022.3.32f1` or later, but the SDK's minimum supported Unity version is `2021.2` as the SDK requires C# 9. This tutorial has been tested with the following Unity versions.
 
 - `2022.3.32f1 LTS`
 - `6000.0.33f1`
 
-Please file an issue [here]() if you encounter an issue with a specific Unity version.
+Please file an issue [here](https://github.com/clockworklabs/spacetime-docs/issues) if you encounter an issue with a specific Unity version.
 
 ## Blackhol.io Tutorial - Basic Multiplayer
 
-Get started with the core client-server setup. For part 2, you may choose your server module preference of [Rust](/docs/modules/rust) or [C#](/docs/modules/c-sharp):
+First you'll get started with the core client/server setup. For part 2, you'll be able to choose between [Rust](/docs/modules/rust) or [C#](/docs/modules/c-sharp) for your server module language:
 
 - [Part 1 - Setup](/docs/unity/part-1)
 - [Part 2 - Connecting to SpacetimeDB](/docs/unity/part-2)

--- a/docs/unity/part-1.md
+++ b/docs/unity/part-1.md
@@ -36,7 +36,7 @@ Open Unity and create a new project by selecting "New" from the Unity Hub or goi
 
 **⚠️ Important: Choose the `Universal 2D`** template to select a template which uses the Unity Universal Render Pipeline.
 
-For `Project Name` use `client`. For Project Location make sure that you use your `blackholio` directory. This is the directory that we created in a previous step.
+For `Project Name` use `client-unity`. For Project Location make sure that you use your `blackholio` directory. This is the directory that we created in a previous step.
 
 <!-- ![Universal 2D Template](./part-1-universal-2d-template.png) -->
 

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -10,33 +10,33 @@ If you have not already installed the `spacetime` CLI, check out our [Getting St
 
 In your `blackholio` directory, run the following command to initialize the SpacetimeDB server module project with Rust as the language:
 
-:::rust
+:::server-rust
 Run the following command to initialize the SpacetimeDB server module project with Rust as the language:
 
 ```bash
 spacetime init --lang=rust server-rust
 ```
 
-This command creates a new folder named `server-rust` alongside your Unity project `client` directory and sets up the SpacetimeDB server project with Rust as the programming language.
+This command creates a new folder named `server-rust` alongside your Unity project `client-unity` directory and sets up the SpacetimeDB server project with Rust as the programming language.
 :::
-:::csharp
+:::server-csharp
 Run the following command to initialize the SpacetimeDB server module project with C# as the language:
 
 ```bash
 spacetime init --lang=csharp server-csharp
 ```
 
-This command creates a new folder named `server-csharp` alongside your Unity project `client` directory and sets up the SpacetimeDB server project with C# as the programming language.
+This command creates a new folder named `server-csharp` alongside your Unity project `client-unity` directory and sets up the SpacetimeDB server project with C# as the programming language.
 :::
 
 ### SpacetimeDB Tables
 
-:::rust
+:::server-rust
 In this section we'll be making some edits to the file `server-rust/src/lib.rs`. We recommend you open up this file in an IDE like VSCode or RustRover.
 
 **Important: Open the `server-rust/src/lib.rs` file and delete its contents. We will be writing it from scratch here.**
 :::
-:::csharp
+:::server-csharp
 In this section we'll be making some edits to the file `server-csharp/Lib.cs`. We recommend you open up this file in an IDE like VSCode or Rider.
 
 **Important: Open the `server-csharp/Lib.cs` file and delete its contents. We will be writing it from scratch here.**
@@ -44,7 +44,7 @@ In this section we'll be making some edits to the file `server-csharp/Lib.cs`. W
 
 First we need to add some imports at the top of the file. Some will remain unused for now.
 
-:::rust
+:::server-rust
 **Copy and paste into lib.rs:**
 
 ```rust
@@ -52,7 +52,7 @@ use std::time::Duration;
 use spacetimedb::{rand::Rng, Identity, SpacetimeType, ReducerContext, ScheduleAt, Table, Timestamp};
 ```
 :::
-:::csharp
+:::server-csharp
 **Copy and paste into Lib.cs:**
 
 ```csharp
@@ -67,7 +67,7 @@ public static partial class Module
 
 We are going to start by defining a SpacetimeDB *table*. A *table* in SpacetimeDB is a relational database table which stores rows, similar to something you might find in SQL. SpacetimeDB tables differ from normal relational database tables in that they are stored fully in memory, are blazing fast to access, and are defined in your module code, rather than in SQL.
 
-:::rust
+:::server-rust
 Each row in a SpacetimeDB table is associated with a `struct` type in Rust.
 
 Let's start by defining the `Config` table. This is a simple table which will store some metadata about our game's state. Add the following code to `lib.rs`.
@@ -85,7 +85,7 @@ pub struct Config {
 
 Let's break down this code. This defines a normal Rust `struct` with two fields: `id` and `world_size`. We have decorated the struct with the `spacetimedb::table` macro. This procedural Rust macro signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
 :::
-:::csharp
+:::server-csharp
 Each row in a SpacetimeDB table is associated with a `struct` type in C#.
 
 Let's start by defining the `Config` table. This is a simple table which will store some metadata about our game's state. Add the following code inside the `Module` class in `Lib.cs`.
@@ -107,12 +107,12 @@ Let's break down this code. This defines a normal C# `struct` with two fields: `
 
 > NOTE: It is possible to have two different tables with different table names share the same type.
 
-:::rust
+:::server-rust
 The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
 :::
-:::csharp
+:::server-csharp
 The `Table` attribute with takes two parameters, a `Name` which is the name of the table and what you will use to query the table in SQL, and a `Public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `[PrimaryKey]` attribute, specifies that the `id` field should be used as the primary key of the table.
@@ -120,16 +120,16 @@ The `[PrimaryKey]` attribute, specifies that the `id` field should be used as th
 
 > NOTE: The primary key of a row defines the "identity" of the row. A change to a row which doesn't modify the primary key is considered an update, but if you change the primary key, then you have deleted the old row and inserted a new one.
 
-:::rust
+:::server-rust
 You can learn more the `table` macro in our [Rust module reference](/docs/modules/rust).
 :::
-:::csharp
+:::server-csharp
 You can learn more the `Table` attribute in our [C# module reference](/docs/modules/c-sharp).
 :::
 
 ### Creating Entities
 
-:::rust
+:::server-rust
 Next, we're going to define a new `SpacetimeType` called `DbVector2` which we're going to use to store positions. The difference between a `#[derive(SpacetimeType)]` and a `#[spacetimedb(table)]` is that tables actually store data, whereas the deriving `SpacetimeType` just allows you to create a new column of that type in a SpacetimeDB table. Therefore, `DbVector2` is only a type, and does not define a table.
 
 **Append to the bottom of lib.rs:**
@@ -176,7 +176,7 @@ pub struct Food {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 Next, we're going to define a new `SpacetimeType` called `DbVector2` which we're going to use to store positions. The difference between a `[SpacetimeDB.Type]` and a `[SpacetimeDB.Table]` is that tables actually store data, whereas the deriving `SpacetimeType` just allows you to create a new column of that type in a SpacetimeDB table. Therefore, `DbVector2` is only a type, and does not define a table.
 
 **Append to the bottom of Lib.cs:**
@@ -243,7 +243,7 @@ The `Circle` table, however, represents an entity that is controlled by a player
 
 Next, let's create a table to store our player data.
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::table(name = player, public)]
 #[derive(Debug, Clone)]
@@ -259,7 +259,7 @@ pub struct Player {
 
 There's a few new concepts we should touch on. First of all, we are using the `#[unique]` attribute on the `player_id` field. This attribute adds a constraint to the table that ensures that only one row in the player table has a particular `player_id`.
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Table(Name = "player", Public = true)]
 					   
@@ -283,7 +283,7 @@ We also have an `identity` field which uses the `Identity` type. The `Identity` 
 
 Next, we write our very first reducer. A reducer is a module function which can be called by clients. Let's write a simple debug reducer to see how they work.
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::reducer]
 pub fn debug(ctx: &ReducerContext) -> Result<(), String> {
@@ -292,7 +292,7 @@ pub fn debug(ctx: &ReducerContext) -> Result<(), String> {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Reducer]
 public static void Debug(ReducerContext ctx)
@@ -330,10 +330,10 @@ This following log output indicates that SpacetimeDB is successfully running on 
 Starting SpacetimeDB listening on 127.0.0.1:3000
 ```
 
-:::rust
+:::server-rust
 Now that SpacetimeDB is running we can publish our module to the SpacetimeDB host. In a separate terminal window, navigate to the `blackholio/server-rust` directory.
 :::
-:::csharp
+:::server-csharp
 Now that SpacetimeDB is running we can publish our module to the SpacetimeDB host. In a separate terminal window, navigate to the `blackholio/server-csharp` directory.
 :::
 
@@ -350,14 +350,14 @@ Created new database with name: blackholio, identity: c200d2c69b4524292b91822afa
 
 > If you sign into `spacetime login` via GitHub, the token you get will be issued by `auth.spacetimedb.com`. This will also ensure that you can recover your identity in case you lose it. On the other hand, if you do `spacetime login --server-issued-login local`, you will get an identity which is issued directly by your local server. Do note, however, that `--server-issued-login` tokens are not recoverable if lost, and are only recognized by the server that issued them.
 
-:::rust
+:::server-rust
 Next, use the `spacetime` command to call our newly defined `debug` reducer:
 
 ```sh
 spacetime call blackholio debug
 ```
 :::
-:::csharp
+:::server-csharp
 Next, use the `spacetime` command to call our newly defined `Debug` reducer:
 
 ```sh
@@ -385,7 +385,7 @@ You should see something like the following output:
 
 ### Connecting our Client
 
-:::rust
+:::server-rust
 Next let's connect our client to our module. Let's start by modifying our `debug` reducer. Rename the reducer to be called `connect` and add `client_connected` in parentheses after `spacetimedb::reducer`. The end result should look like this:
 
 ```rust
@@ -404,7 +404,7 @@ The `client_connected` argument to the `spacetimedb::reducer` macro indicates to
 > - `client_connected` - Called when a user connects to the SpacetimeDB module. Their identity can be found in the `sender` value of the `ReducerContext`.
 > - `client_disconnected` - Called when a user disconnects from the SpacetimeDB module.
 :::
-:::csharp
+:::server-csharp
 Next let's connect our client to our module. Let's start by modifying our `Debug` reducer. Rename the reducer to be called `Connect` and add `ReducerKind.ClientConnected` in parentheses after `SpacetimeDB.Reducer`. The end result should look like this:
 
 ```csharp
@@ -434,26 +434,26 @@ spacetime publish --server local blackholio
 
 The `spacetime` CLI has built in functionality to let us generate C# types that correspond to our tables, types, and reducers that we can use from our Unity client.
 
-:::rust
+:::server-rust
 Let's generate our types for our module. In the `blackholio/server-rust` directory run the following command:
 :::
-:::csharp
+:::server-csharp
 Let's generate our types for our module. In the `blackholio/server-csharp` directory run the following command:
 :::
 
 ```sh
-spacetime generate --lang csharp --out-dir ../client/Assets/autogen # you can call this anything, I have chosen `autogen`
+spacetime generate --lang csharp --out-dir ../client-unity/Assets/autogen # you can call this anything, I have chosen `autogen`
 ```
 
-This will generate a set of files in the `client/Assets/autogen` directory which contain the code generated types and reducer functions that are defined in your module, but usable on the client.
+This will generate a set of files in the `client-unity/Assets/autogen` directory which contain the code generated types and reducer functions that are defined in your module, but usable on the client.
 
 ```sh
-ls ../client/Assets/autogen/*.cs
-../client/Assets/autogen/Circle.cs	../client/Assets/autogen/DbVector2.cs	../client/Assets/autogen/Food.cs
-../client/Assets/autogen/Config.cs	../client/Assets/autogen/Entity.cs	../client/Assets/autogen/Player.cs
+ls ../client-unity/Assets/autogen/*.cs
+../client-unity/Assets/autogen/Circle.cs	../client-unity/Assets/autogen/DbVector2.cs	../client-unity/Assets/autogen/Food.cs
+../client-unity/Assets/autogen/Config.cs	../client-unity/Assets/autogen/Entity.cs	../client-unity/Assets/autogen/Player.cs
 ```
 
-This will also generate a file in the `client/Assets/autogen/_Globals` directory with a type aware `DbConnection` class. We will use this class to connect to your module from Unity.
+This will also generate a file in the `client-unity/Assets/autogen/_Globals` directory with a type aware `DbConnection` class. We will use this class to connect to your module from Unity.
 
 > IMPORTANT! At this point there will be an error in your Unity project. Due to a [known issue](https://docs.unity3d.com/6000.0/Documentation/Manual/csharp-compiler.html) with Unity and C# 9 you need to insert the following code into your Unity project.
 >

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -84,6 +84,10 @@ pub struct Config {
 ```
 
 Let's break down this code. This defines a normal Rust `struct` with two fields: `id` and `world_size`. We have decorated the struct with the `spacetimedb::table` macro. This procedural Rust macro signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
+
+The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
+
+The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
 :::
 :::server-csharp
 Each row in a SpacetimeDB table is associated with a `struct` type in C#.
@@ -105,14 +109,7 @@ public partial struct Config
 Let's break down this code. This defines a normal C# `struct` with two fields: `id` and `world_size`. We have added the `[Table(Name = "config", Public = true)]` attribute the struct. This attribute signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
 
 > Although we're using `lower_snake_case` for our column names to have consistent column names across languages in this tutorial, you can also use `camelCase` or `PascalCase` if you prefer. See [#2168](https://github.com/clockworklabs/SpacetimeDB/issues/2168) for more information.
-:::
-
-:::server-rust
-The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
-
-The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
-:::
-:::server-csharp
+ 
 The `Table` attribute with takes two parameters, a `Name` which is the name of the table and what you will use to query the table in SQL, and a `Public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `[PrimaryKey]` attribute, specifies that the `id` field should be used as the primary key of the table.

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -103,9 +103,9 @@ public partial struct Config
 ```
 
 Let's break down this code. This defines a normal C# `struct` with two fields: `id` and `world_size`. We have added the `[Table(Name = "config", Public = true)]` attribute the struct. This attribute signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
-:::
 
-> NOTE: It is possible to have two different tables with different table names share the same type.
+> Although we're using `lower_snake_case` for our column names to have consistent column names across languages in this tutorial, you can also use `camelCase` or `PascalCase` if you prefer. See [#2168](https://github.com/clockworklabs/SpacetimeDB/issues/2168) for more information.
+:::
 
 :::server-rust
 The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -201,7 +201,6 @@ Let's create a few tables to represent entities in our game by adding the follow
 
 ```csharp
 [Table(Name = "entity", Public = true)]
-					   
 public partial struct Entity
 {
 	[PrimaryKey, AutoInc] 
@@ -219,7 +218,7 @@ public partial struct Circle
     public uint player_id;
     public DbVector2 direction;
     public float speed;
-    public long last_split_time;
+    public ulong last_split_time;
 }
 
 [Table(Name = "food", Public = true)]
@@ -262,13 +261,11 @@ There's a few new concepts we should touch on. First of all, we are using the `#
 :::server-csharp
 ```csharp
 [Table(Name = "player", Public = true)]
-					   
 public partial struct Player
 {
 	[PrimaryKey]
 	public Identity identity;
 	[Unique, AutoInc]
-			   
 	public uint player_id;
 	public string name;
 }

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -287,6 +287,9 @@ pub fn debug(ctx: &ReducerContext) -> Result<(), String> {
 ```
 :::
 :::server-csharp
+
+Add this function to the `Module` class in `Lib.cs`:
+
 ```csharp
 [Reducer]
 public static void Debug(ReducerContext ctx)

--- a/docs/unity/part-2.md
+++ b/docs/unity/part-2.md
@@ -6,31 +6,68 @@ This progressive tutorial is continued from [part 1](/docs/unity/part-1).
 
 ## Create a Server Module
 
+If you have not already installed the `spacetime` CLI, check out our [Getting Started](/docs/getting-started) guide for instructions on how to install.
+
+In your `blackholio` directory, run the following command to initialize the SpacetimeDB server module project with Rust as the language:
+
+:::rust
 Run the following command to initialize the SpacetimeDB server module project with Rust as the language:
 
 ```bash
-spacetime init --lang=rust rust-server
+spacetime init --lang=rust server-rust
 ```
 
-This command creates a new folder named "rust-server" within your Unity project directory and sets up the SpacetimeDB server project with Rust as the programming language.
+This command creates a new folder named `server-rust` alongside your Unity project `client` directory and sets up the SpacetimeDB server project with Rust as the programming language.
+:::
+:::csharp
+Run the following command to initialize the SpacetimeDB server module project with C# as the language:
+
+```bash
+spacetime init --lang=csharp server-csharp
+```
+
+This command creates a new folder named `server-csharp` alongside your Unity project `client` directory and sets up the SpacetimeDB server project with C# as the programming language.
+:::
 
 ### SpacetimeDB Tables
 
-In this section we'll be making some edits to the file `server/src/lib.rs`. We recommend you open up this file in an IDE like VSCode or RustRover.
+:::rust
+In this section we'll be making some edits to the file `server-rust/src/lib.rs`. We recommend you open up this file in an IDE like VSCode or RustRover.
 
-**Important: Open the `server/src/lib.rs` file and delete its contents. We will be writing it from scratch here.**
+**Important: Open the `server-rust/src/lib.rs` file and delete its contents. We will be writing it from scratch here.**
+:::
+:::csharp
+In this section we'll be making some edits to the file `server-csharp/Lib.cs`. We recommend you open up this file in an IDE like VSCode or Rider.
+
+**Important: Open the `server-csharp/Lib.cs` file and delete its contents. We will be writing it from scratch here.**
+:::
 
 First we need to add some imports at the top of the file. Some will remain unused for now.
 
+:::rust
 **Copy and paste into lib.rs:**
 
 ```rust
 use std::time::Duration;
 use spacetimedb::{rand::Rng, Identity, SpacetimeType, ReducerContext, ScheduleAt, Table, Timestamp};
 ```
+:::
+:::csharp
+**Copy and paste into Lib.cs:**
+
+```csharp
+using SpacetimeDB;
+
+public static partial class Module
+{
+
+}
+```
+:::
 
 We are going to start by defining a SpacetimeDB *table*. A *table* in SpacetimeDB is a relational database table which stores rows, similar to something you might find in SQL. SpacetimeDB tables differ from normal relational database tables in that they are stored fully in memory, are blazing fast to access, and are defined in your module code, rather than in SQL.
 
+:::rust
 Each row in a SpacetimeDB table is associated with a `struct` type in Rust.
 
 Let's start by defining the `Config` table. This is a simple table which will store some metadata about our game's state. Add the following code to `lib.rs`.
@@ -47,19 +84,52 @@ pub struct Config {
 ```
 
 Let's break down this code. This defines a normal Rust `struct` with two fields: `id` and `world_size`. We have decorated the struct with the `spacetimedb::table` macro. This procedural Rust macro signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
+:::
+:::csharp
+Each row in a SpacetimeDB table is associated with a `struct` type in C#.
+
+Let's start by defining the `Config` table. This is a simple table which will store some metadata about our game's state. Add the following code inside the `Module` class in `Lib.cs`.
+
+```csharp
+// We're using this table as a singleton, so in this table
+// there only be one element where the `id` is 0.
+[Table(Name = "config", Public = true)]
+public partial struct Config
+{
+    [PrimaryKey]
+    public uint id;
+    public ulong world_size;
+}
+```
+
+Let's break down this code. This defines a normal C# `struct` with two fields: `id` and `world_size`. We have added the `[Table(Name = "config", Public = true)]` attribute the struct. This attribute signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
+:::
 
 > NOTE: It is possible to have two different tables with different table names share the same type.
 
+:::rust
 The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
+:::
+:::csharp
+The `Table` attribute with takes two parameters, a `Name` which is the name of the table and what you will use to query the table in SQL, and a `Public` visibility modifier which ensures that the rows of this table are visible to everyone.
+
+The `[PrimaryKey]` attribute, specifies that the `id` field should be used as the primary key of the table.
+:::
 
 > NOTE: The primary key of a row defines the "identity" of the row. A change to a row which doesn't modify the primary key is considered an update, but if you change the primary key, then you have deleted the old row and inserted a new one.
 
+:::rust
 You can learn more the `table` macro in our [Rust module reference](/docs/modules/rust).
+:::
+:::csharp
+You can learn more the `Table` attribute in our [C# module reference](/docs/modules/c-sharp).
+:::
 
 ### Creating Entities
 
+:::rust
 Next, we're going to define a new `SpacetimeType` called `DbVector2` which we're going to use to store positions. The difference between a `#[derive(SpacetimeType)]` and a `#[spacetimedb(table)]` is that tables actually store data, whereas the deriving `SpacetimeType` just allows you to create a new column of that type in a SpacetimeDB table. Therefore, `DbVector2` is only a type, and does not define a table.
 
 **Append to the bottom of lib.rs:**
@@ -105,6 +175,61 @@ pub struct Food {
     pub entity_id: u32,
 }
 ```
+:::
+:::csharp
+Next, we're going to define a new `SpacetimeType` called `DbVector2` which we're going to use to store positions. The difference between a `[SpacetimeDB.Type]` and a `[SpacetimeDB.Table]` is that tables actually store data, whereas the deriving `SpacetimeType` just allows you to create a new column of that type in a SpacetimeDB table. Therefore, `DbVector2` is only a type, and does not define a table.
+
+**Append to the bottom of Lib.cs:**
+
+```csharp
+// This allows us to store 2D points in tables.
+[SpacetimeDB.Type]
+public partial struct DbVector2
+{
+    public float x;
+    public float y;
+
+    public DbVector2(float x, float y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+}
+```
+
+Let's create a few tables to represent entities in our game by adding the following to the end of the `Module` class.
+
+```csharp
+[Table(Name = "entity", Public = true)]
+					   
+public partial struct Entity
+{
+	[PrimaryKey, AutoInc] 
+	public uint entity_id;
+	public DbVector2 position;
+	public uint mass;
+}
+
+[Table(Name = "circle", Public = true)]
+public partial struct Circle
+{
+    [PrimaryKey]
+    public uint entity_id;
+    [SpacetimeDB.Index.BTree]
+    public uint player_id;
+    public DbVector2 direction;
+    public float speed;
+    public long last_split_time;
+}
+
+[Table(Name = "food", Public = true)]
+public partial struct Food
+{
+	[PrimaryKey]
+	public uint entity_id;
+}
+```
+:::
 
 The first table we defined is the `entity` table. An entity represents an object in our game world. We have decided, for convenience, that all entities in our game should share some common fields, namely `position` and `mass`.
 
@@ -118,6 +243,7 @@ The `Circle` table, however, represents an entity that is controlled by a player
 
 Next, let's create a table to store our player data.
 
+:::rust
 ```rust
 #[spacetimedb::table(name = player, public)]
 #[derive(Debug, Clone)]
@@ -132,6 +258,24 @@ pub struct Player {
 ```
 
 There's a few new concepts we should touch on. First of all, we are using the `#[unique]` attribute on the `player_id` field. This attribute adds a constraint to the table that ensures that only one row in the player table has a particular `player_id`.
+:::
+:::csharp
+```csharp
+[Table(Name = "player", Public = true)]
+					   
+public partial struct Player
+{
+	[PrimaryKey]
+	public Identity identity;
+	[Unique, AutoInc]
+			   
+	public uint player_id;
+	public string name;
+}
+```
+
+There's a few new concepts we should touch on. First of all, we are using the `[Unique]` attribute on the `player_id` field. This attribute adds a constraint to the table that ensures that only one row in the player table has a particular `player_id`. We are also using the `[AutoInc]` attribute on the `player_id` field, which indicates "this field should get automatically assigned an auto-incremented value".
+:::
 
 We also have an `identity` field which uses the `Identity` type. The `Identity` type is a identifier that SpacetimeDB uses to uniquely assign and authenticate SpacetimeDB users.
 
@@ -139,6 +283,7 @@ We also have an `identity` field which uses the `Identity` type. The `Identity` 
 
 Next, we write our very first reducer. A reducer is a module function which can be called by clients. Let's write a simple debug reducer to see how they work.
 
+:::rust
 ```rust
 #[spacetimedb::reducer]
 pub fn debug(ctx: &ReducerContext) -> Result<(), String> {
@@ -146,6 +291,16 @@ pub fn debug(ctx: &ReducerContext) -> Result<(), String> {
     Ok(())
 }
 ```
+:::
+:::csharp
+```csharp
+[Reducer]
+public static void Debug(ReducerContext ctx)
+{
+    Log.Info($"This reducer was called by {ctx.CallerIdentity}");	  
+}
+```
+:::
 
 This reducer doesn't update any tables, it just prints out the `Identity` of the client that called it.
 
@@ -175,7 +330,14 @@ This following log output indicates that SpacetimeDB is successfully running on 
 Starting SpacetimeDB listening on 127.0.0.1:3000
 ```
 
-Now that SpacetimeDB is running we can publish our module to the SpacetimeDB host. In a separate terminal window, navigate to the `blackholio/server-rust` directory and run `spacetime publish --server local blackholio`. This will publish our Blackholio server logic to SpacetimeDB.
+:::rust
+Now that SpacetimeDB is running we can publish our module to the SpacetimeDB host. In a separate terminal window, navigate to the `blackholio/server-rust` directory.
+:::
+:::csharp
+Now that SpacetimeDB is running we can publish our module to the SpacetimeDB host. In a separate terminal window, navigate to the `blackholio/server-csharp` directory.
+:::
+
+If you are not already logged in to the `spacetime` CLI, run the `spacetime login` command log in to your SpacetimeDB website account. Once you are logged in, run `spacetime publish --server local blackholio`. This will publish our Blackholio server logic to SpacetimeDB.
 
 If the publish completed successfully, you will see something like the following in the logs:
 
@@ -186,11 +348,22 @@ Publishing module...
 Created new database with name: blackholio, identity: c200d2c69b4524292b91822afac8ab016c15968ac993c28711f68c6bc40b89d5
 ```
 
+> If you sign into `spacetime login` via GitHub, the token you get will be issued by `auth.spacetimedb.com`. This will also ensure that you can recover your identity in case you lose it. On the other hand, if you do `spacetime login --server-issued-login local`, you will get an identity which is issued directly by your local server. Do note, however, that `--server-issued-login` tokens are not recoverable if lost, and are only recognized by the server that issued them.
+
+:::rust
 Next, use the `spacetime` command to call our newly defined `debug` reducer:
 
 ```sh
 spacetime call blackholio debug
 ```
+:::
+:::csharp
+Next, use the `spacetime` command to call our newly defined `Debug` reducer:
+
+```sh
+spacetime call blackholio Debug
+```
+:::
 
 If the call completed successfully, that command will have no output, but we can see the debug logs by running:
 
@@ -212,6 +385,7 @@ You should see something like the following output:
 
 ### Connecting our Client
 
+:::rust
 Next let's connect our client to our module. Let's start by modifying our `debug` reducer. Rename the reducer to be called `connect` and add `client_connected` in parentheses after `spacetimedb::reducer`. The end result should look like this:
 
 ```rust
@@ -229,7 +403,26 @@ The `client_connected` argument to the `spacetimedb::reducer` macro indicates to
 > - `init` - Called the first time you publish your module and anytime you clear the database with `spacetime publish <name> --delete-data`.
 > - `client_connected` - Called when a user connects to the SpacetimeDB module. Their identity can be found in the `sender` value of the `ReducerContext`.
 > - `client_disconnected` - Called when a user disconnects from the SpacetimeDB module.
+:::
+:::csharp
+Next let's connect our client to our module. Let's start by modifying our `Debug` reducer. Rename the reducer to be called `Connect` and add `ReducerKind.ClientConnected` in parentheses after `SpacetimeDB.Reducer`. The end result should look like this:
 
+```csharp
+[Reducer(ReducerKind.ClientConnected)]
+public static void Connect(ReducerContext ctx)
+{
+    Log.Info($"{ctx.CallerIdentity} just connected.");
+}
+```
+
+The `ReducerKind.ClientConnected` argument to the `SpacetimeDB.Reducer` attribute indicates to SpacetimeDB that this is a special reducer. This reducer is only every called by SpacetimeDB itself when a client connects to your module.
+
+> SpacetimeDB gives you the ability to define custom reducers that automatically trigger when certain events occur.
+> 
+> - `ReducerKind.Init` - Called the first time you publish your module and anytime you clear the database with `spacetime publish <name> --delete-data`.
+> - `ReducerKind.ClientConnected` - Called when a user connects to the SpacetimeDB module. Their identity can be found in the `CallerIdentity` value of the `ReducerContext`.
+> - `ReducerKind.ClientDisconnected` - Called when a user disconnects from the SpacetimeDB module.
+:::
 
 Publish your module again by running:
 
@@ -241,7 +434,12 @@ spacetime publish --server local blackholio
 
 The `spacetime` CLI has built in functionality to let us generate C# types that correspond to our tables, types, and reducers that we can use from our Unity client.
 
+:::rust
 Let's generate our types for our module. In the `blackholio/server-rust` directory run the following command:
+:::
+:::csharp
+Let's generate our types for our module. In the `blackholio/server-csharp` directory run the following command:
+:::
 
 ```sh
 spacetime generate --lang csharp --out-dir ../client/Assets/autogen # you can call this anything, I have chosen `autogen`
@@ -359,7 +557,6 @@ public class GameManager : MonoBehaviour
         Debug.Log("Subscription applied!");
         OnSubscriptionApplied?.Invoke();
     }
-
 
     public static bool IsConnected()
     {

--- a/docs/unity/part-3.md
+++ b/docs/unity/part-3.md
@@ -240,7 +240,7 @@ public static void Init(ReducerContext ctx)
     ctx.Db.spawn_food_timer.Insert(new SpawnFoodTimer
     {
         scheduled_at = new ScheduleAt.Interval(TimeSpan.FromMilliseconds(500))
-    });	  
+    });
 }
 ```
 
@@ -549,7 +549,7 @@ public static void Disconnect(ReducerContext ctx)
     // Remove any circles from the arena
     foreach (var circle in ctx.Db.circle.player_id.Filter(player.player_id))
     {
-        var entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Could not find circle");								  
+        var entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Could not find circle");
         ctx.Db.entity.entity_id.Delete(entity.entity_id);
         ctx.Db.circle.entity_id.Delete(entity.entity_id);
     }

--- a/docs/unity/part-3.md
+++ b/docs/unity/part-3.md
@@ -6,6 +6,7 @@ This progressive tutorial is continued from [part 2](/docs/unity/part-2).
 
 ### Spawning Food
 
+:::rust
 Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `init` reducer. SpacetimeDB calls the `init` reducer automatically when first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your module before any clients connect.
 
 Add this new reducer above our `connect` reducer.
@@ -75,14 +76,84 @@ pub fn spawn_food(ctx: &ReducerContext) -> Result<(), String> {
     Ok(())
 }
 ```
+:::
+:::csharp
+Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `Init` reducer. SpacetimeDB calls the `Init` reducer automatically when you first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your module before any clients connect.
+
+Add this new reducer above our `Connect` reducer.
+
+```csharp
+// Note the `init` parameter passed to the reducer macro.
+// That indicates to SpacetimeDB that it should be called
+// once upon database creation.
+[Reducer(ReducerKind.Init)]
+public static void Init(ReducerContext ctx)
+{
+    Log.Info($"Initializing...");
+    ctx.Db.config.Insert(new Config { world_size = 1000 });
+}
+```
+
+This reducer also demonstrates how to insert new rows into a table. Here we are adding a single `Config` row to the `config` table with the `Insert` function.
+
+Now that we've ensured that our database always has a valid `world_size` let's spawn some food into the map. Add the following code to the end of the `Module` class.
+
+```csharp
+const uint FOOD_MASS_MIN = 2;
+const uint FOOD_MASS_MAX = 4;
+const uint TARGET_FOOD_COUNT = 600;
+
+public static float MassToRadius(uint mass) => MathF.Sqrt(mass);
+
+[Reducer]
+public static void SpawnFood(ReducerContext ctx)
+{
+    if (ctx.Db.player.Count == 0) //Are there no players yet?
+    {
+        return;
+    }
+
+    var world_size = (ctx.Db.config.id.Find(0) ?? throw new Exception("Config not found")).world_size;
+    var rng = ctx.Rng;
+    var food_count = ctx.Db.food.Count;
+    while (food_count < TARGET_FOOD_COUNT)
+    {
+        var food_mass = rng.Range(FOOD_MASS_MIN, FOOD_MASS_MAX);
+        var food_radius = MassToRadius(food_mass);
+        var x = rng.Range(food_radius, world_size - food_radius);
+        var y = rng.Range(food_radius, world_size - food_radius);
+        var entity = ctx.Db.entity.Insert(new Entity()
+        {
+            position = new DbVector2(x, y),
+            mass = food_mass,
+        });
+        ctx.Db.food.Insert(new Food
+        {
+            entity_id = entity.entity_id,
+        });
+        food_count++;
+        Log.Info($"Spawned food! {entity.entity_id}");
+    }
+}
+
+public static float Range(this Random rng, float min, float max) => rng.NextSingle() * (max - min) + min;
+
+public static uint Range(this Random rng, uint min, uint max) => (uint)rng.NextInt64(min, max);
+```
+:::
 
 In this reducer, we are using the `world_size` we configured along with the `ReducerContext`'s random number generator `.rng()` function to place 600 food uniformly randomly throughout the map. We've also chosen the `mass` of the food to be a random number between 2 and 4 inclusive.
 
+:::csharp
+We also added two helper functions so we can get a random range as either a `uint` or a `float`.
+
+:::
 Although, we've written the reducer to spawn food, no food will actually be spawned until we call the function while players are logged in. This raises the question, who should call this function and when?
 
 We would like for this function to be called periodically to "top up" the amount of food on the map so that it never falls very far below our target amount of food. SpacetimeDB has built in functionality for exactly this. With SpacetimeDB you can schedule your module to call itself in the future or repeatedly with reducers.
 
-In order to schedule a reducer to be called we have to create a new table which specifies when an how a reducer should be called. Add this new table to the top of the file.
+:::rust
+In order to schedule a reducer to be called we have to create a new table which specifies when an how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
 #[spacetimedb::table(name = spawn_food_timer, scheduled(spawn_food))]
@@ -95,20 +166,48 @@ pub struct SpawnFoodTimer {
 ```
 
 Note the `scheduled(spawn_food)` parameter in the table macro. This tells SpacetimeDB that the rows in this table specify a schedule for when the `spawn_food` reducer should be called. Each scheduled table requires a `scheduled_id` and a `scheduled_at` field so that SpacetimeDB can call your reducer, however you can also add your own fields to these rows as well.
+:::
+:::csharp
+In order to schedule a reducer to be called we have to create a new table which specifies when an how a reducer should be called. Add this new table to the top of the `Module` class.
+
+```csharp
+[Table(Name = "spawn_food_timer", Scheduled = nameof(SpawnFood), ScheduledAt = "scheduled_at")]
+public partial struct SpawnFoodTimer
+{
+    [PrimaryKey, AutoInc]
+    public ulong scheduled_id;
+    public ScheduleAt scheduled_at;
+}
+```
+
+Note the `Scheduled = nameof(SpawnFood)` parameter in the table macro. This tells SpacetimeDB that the rows in this table specify a schedule for when the `SpawnFood` reducer should be called. Each scheduled table requires a `scheduled_id` and a `scheduled_at` field so that SpacetimeDB can call your reducer, however you can also add your own fields to these rows as well.
+:::
 
 You can create, delete, or change a schedule by inserting, deleting, or updating rows in this table. 
 
 You will see an error telling you that the `spawn_food` reducer needs to take two arguments, but currently only takes one. This is because the schedule row must be passed in to all scheduled reducers. Modify your `spawn_food` reducer to take the scheduled row as an argument.
 
+:::rust
 ```rust
 #[spacetimedb::reducer]
 pub fn spawn_food(ctx: &ReducerContext, _timer: SpawnFoodTimer) -> Result<(), String> {
     // ...
 }
 ```
+:::
+:::csharp
+```csharp
+[Reducer]
+public static void SpawnFood(ReducerContext ctx, SpawnFoodTimer _timer)
+{
+    // ...
+}
+```
+:::
 
 In our case we aren't interested in the data on the row, so we name the argument `_timer`.
 
+:::rust
 Let's modify our `init` reducer to schedule our `spawn_food` reducer to be called every 500 milliseconds.
 
 ```rust
@@ -128,6 +227,29 @@ pub fn init(ctx: &ReducerContext) -> Result<(), String> {
 ```
 
 > You can use `ScheduleAt::Interval` to schedule a reducer call at an interval like we're doing here. SpacetimeDB will continue to call the reducer at this interval until you remove the row. You can also use `ScheduleAt::Time()` to specify a specific at which to call a reducer once. SpacetimeDB will remove that row automatically after the reducer has been called.
+:::
+:::csharp
+Let's modify our `Init` reducer to schedule our `SpawnFood` reducer to be called every 500 milliseconds.
+
+```csharp
+[Reducer(ReducerKind.Init)]
+public static void Init(ReducerContext ctx)
+{
+    Log.Info($"Initializing...");
+    ctx.Db.config.Insert(new Config { world_size = 1000 });
+			  
+						 
+		
+    ctx.Db.spawn_food_timer.Insert(new SpawnFoodTimer
+    {
+        scheduled_at = new ScheduleAt.Interval(TimeSpan.FromMilliseconds(500))
+    });
+		  
+}
+```
+
+> You can use `ScheduleAt.Interval` to schedule a reducer call at an interval like we're doing here. SpacetimeDB will continue to call the reducer at this interval until you remove the row. You can also use `ScheduleAt.Time()` to specify a specific at which to call a reducer once. SpacetimeDB will remove that row automatically after the reducer has been called.
+:::
 
 ### Logging Players In
 
@@ -135,12 +257,20 @@ Let's continue building out our server module by modifying it to log in a player
 
 Let's add a second table to our `Player` struct. Modify the `Player` struct by adding this above the struct:
 
+:::rust
 ```rust
 #[spacetimedb::table(name = logged_out_player)]
 ```
+:::
+:::csharp
+```csharp
+[Table(Name = "logged_out_player")]
+```
+:::
 
 Your struct should now look like this:
 
+:::rust
 ```rust
 #[spacetimedb::table(name = player, public)]
 #[spacetimedb::table(name = logged_out_player)]
@@ -154,6 +284,21 @@ pub struct Player {
     name: String,
 }
 ```
+:::
+:::csharp
+```csharp
+[Table(Name = "player", Public = true)]
+[Table(Name = "logged_out_player")]
+public partial struct Player
+{
+    [PrimaryKey]
+    public Identity identity;
+    [Unique, AutoInc]
+    public uint player_id;
+    public string name;
+}
+```
+:::
 
 This line creates an additional tabled called `logged_out_player` whose rows share the same `Player` type as in the `player` table.
 
@@ -161,6 +306,7 @@ This line creates an additional tabled called `logged_out_player` whose rows sha
 >
 > If your client isn't syncing rows from the server, check that your table is not accidentally marked private.
 
+:::rust
 Next, modify your `connect` reducer and add a new `disconnect` reducer below it:
 
 ```rust
@@ -192,6 +338,39 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
     Ok(())
 }
 ```
+:::
+:::csharp
+Next, modify your `Connect` reducer and add a new `Disconnect` reducer below it:
+
+```csharp
+[Reducer(ReducerKind.ClientConnected)]
+public static void Connect(ReducerContext ctx)
+{
+    var player = ctx.Db.logged_out_player.identity.Find(ctx.CallerIdentity);
+    if (player != null)
+    {
+        ctx.Db.player.Insert(player.Value);
+        ctx.Db.logged_out_player.Delete(player.Value);
+    }
+    else
+    {
+        ctx.Db.player.Insert(new Player
+        {
+            identity = ctx.CallerIdentity,
+            name = "",
+        });
+    }
+}
+
+[Reducer(ReducerKind.ClientDisconnected)]
+public static void Disconnect(ReducerContext ctx)
+{
+    var player = ctx.Db.player.identity.Find(ctx.CallerIdentity) ?? throw new Exception("Player not found");
+    ctx.Db.logged_out_player.Insert(player);
+    ctx.Db.player.Delete(player);
+}
+```
+:::
 
 Now when a client connects, if the player corresponding to the client is in the `logged_out_player` table, we will move them into the `player` table, thus indicating that they are logged in and connected. For any new unrecognized client connects we will create a `Player` and insert it into the `player` table.
 
@@ -208,6 +387,7 @@ When a player disconnects, we will transfer their player row from the `player` t
 
 Now that we've got our food spawning and our players set up, let's create a match and spawn player circle entities into it. The first thing we should do before spawning a player into a match is give them a name. 
 
+:::rust
 Add the following to the bottom of your file.
 
 ```rust
@@ -271,9 +451,65 @@ fn spawn_circle_at(
 ```
 
 The `enter_game` reducer takes one argument, the player's `name`. We can use this name to display as a label for the player in the match, by storing the name on the player's row. We are also spawning some circles for the player to control now that they are entering the game. To do this, we choose a random position within the bounds of the arena and create a new entity and corresponding circle row.
+:::
+:::csharp
+Add the following to the end of the `Module` class.
+
+```csharp
+const uint START_PLAYER_MASS = 15;
+
+[Reducer]
+public static void EnterGame(ReducerContext ctx, string name)
+{
+    Log.Info($"Creating player with name {name}");
+    var player = ctx.Db.player.identity.Find(ctx.CallerIdentity) ?? throw new Exception("Player not found");
+    player.name = name;
+    ctx.Db.player.identity.Update(player);
+    SpawnPlayerInitialCircle(ctx, player.player_id);
+}
+
+public static Entity SpawnPlayerInitialCircle(ReducerContext ctx, uint player_id)
+{
+    var rng = ctx.Rng;
+    var world_size = (ctx.Db.config.id.Find(0) ?? throw new Exception("Config not found")).world_size;
+    var player_start_radius = MassToRadius(START_PLAYER_MASS);
+    var x = rng.Range(player_start_radius, world_size - player_start_radius);
+    var y = rng.Range(player_start_radius, world_size - player_start_radius);
+    return SpawnCircleAt(
+        ctx,
+        player_id,
+        START_PLAYER_MASS,
+        new DbVector2(x, y),
+        ctx.Timestamp
+    );
+}
+
+public static Entity SpawnCircleAt(ReducerContext ctx, uint player_id, uint mass, DbVector2 position, DateTimeOffset timestamp)
+{
+    var entity = ctx.Db.entity.Insert(new Entity
+    {
+        position = position,
+        mass = mass,
+    });
+
+    ctx.Db.circle.Insert(new Circle
+    {
+        entity_id = entity.entity_id,
+        player_id = player_id,
+        direction = new DbVector2(0, 1),
+        speed = 0f,
+        last_split_time = timestamp.ToUnixTimeMilliseconds(),
+    });
+    return entity;
+}
+```
+
+The `EnterGame` reducer takes one argument, the player's `name`. We can use this name to display as a label for the player in the match, by storing the name on the player's row. We are also spawning some circles for the player to control now that they are entering the game. To do this, we choose a random position within the bounds of the arena and create a new entity and corresponding circle row.
+:::
 
 Let's also modify our `disconnect` reducer to remove the circles from the arena when the player disconnects from the server.
 
+:::rust
 ```rust
 #[spacetimedb::reducer(client_disconnected)]
 pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
@@ -296,6 +532,26 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
     Ok(())
 }
 ```
+:::
+:::csharp
+```csharp
+[Reducer(ReducerKind.ClientDisconnected)]
+public static void Disconnect(ReducerContext ctx)
+{
+    var player = ctx.Db.player.identity.Find(ctx.CallerIdentity) ?? throw new Exception("Player not found");
+    // Remove any circles from the arena
+    foreach (var circle in ctx.Db.circle.player_id.Filter(player.player_id))
+    {
+        var entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Could not find circle");								  
+        ctx.Db.entity.entity_id.Delete(entity.entity_id);
+        ctx.Db.circle.entity_id.Delete(entity.entity_id);
+    }
+    ctx.Db.logged_out_player.Insert(player);
+    ctx.Db.player.Delete(player);
+}
+```
+:::
+
 
 Finally publish the new module to SpacetimeDB with this command:
 
@@ -466,7 +722,7 @@ The `EntityController` script just provides some helper functions and basic func
 >
 > If you're interested in learning more checkout [this demo](https://gabrielgambetta.com/client-side-prediction-live-demo.html) from Gabriel Gambetta.
 
-Let's also create a new `Extensions.cs` script and replace the contents with:
+At this point you'll have a compilation error because we can't yet convert from `SpacetimeDB.Types.DbVector2` to `UnityEngine.Vector2`. To fix this, let's also create a new `Extensions.cs` script and replace the contents with:
 
 ```cs
 using SpacetimeDB.Types;
@@ -910,15 +1166,19 @@ Lastly modify the `GameManager.SetupArea` method to set the `WorldSize` on the `
 
 ### Entering the Game
 
-The last step is to call the `enter_game` reducer on the server, passing in a username for our player, which will spawn a circle for our player. For the sake of simplicity, let's call the `enter_game` reducer from the `HandleSubscriptionApplied` callback with the name "3Blave".
+:::rust
+At this point, you may need to regenerate your bindings the following command from the `server-rust` directory.
+:::
+:::csharp
+At this point, you may need to regenerate your bindings the following command from the `server-csharp` directory.
+:::
 
-> You may need to regenerate your bindings the following command from the `server-rust` directory.
-> 
-> ```sh
-> spacetime generate --lang csharp --out-dir ../client/Assets/autogen
-> ```
->
-> **BUG WORKAROUND NOTE**: There is currently a bug in the C# code generation that requires you to delete `autogen/LoggedOutPlayer.cs` after running this command.
+```sh
+spacetime generate --lang csharp --out-dir ../client/Assets/autogen
+```
+
+> **BUG WORKAROUND NOTE**: As of `1.0.0-rc3` you will now have a compilation error in Unity. There is currently a bug in the C# code generation that requires you to delete `autogen/LoggedOutPlayer.cs` after running this command.
+The last step is to call the `enter_game` reducer on the server, passing in a username for our player, which will spawn a circle for our player. For the sake of simplicity, let's call the `enter_game` reducer from the `HandleSubscriptionApplied` callback with the name "3Blave".
 
 ```cs
     private void HandleSubscriptionApplied(EventContext ctx)
@@ -941,6 +1201,8 @@ The last step is to call the `enter_game` reducer on the server, passing in a us
 At this point, after publishing our module we can press the play button to see the fruits of our labor! You should be able to see your player's circle, with its username label, surrounded by food.
 
 <!-- ![Player on screen](part-3-player-on-screen.png) -->
+
+> The label won't be centered at this point. Feel free to adjust it if you like. We just didn't want to complicate the tutorial.
 
 ### Troubleshooting
 

--- a/docs/unity/part-3.md
+++ b/docs/unity/part-3.md
@@ -6,7 +6,7 @@ This progressive tutorial is continued from [part 2](/docs/unity/part-2).
 
 ### Spawning Food
 
-:::rust
+:::server-rust
 Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `init` reducer. SpacetimeDB calls the `init` reducer automatically when first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your module before any clients connect.
 
 Add this new reducer above our `connect` reducer.
@@ -77,7 +77,7 @@ pub fn spawn_food(ctx: &ReducerContext) -> Result<(), String> {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `Init` reducer. SpacetimeDB calls the `Init` reducer automatically when you first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your module before any clients connect.
 
 Add this new reducer above our `Connect` reducer.
@@ -144,7 +144,7 @@ public static uint Range(this Random rng, uint min, uint max) => (uint)rng.NextI
 
 In this reducer, we are using the `world_size` we configured along with the `ReducerContext`'s random number generator `.rng()` function to place 600 food uniformly randomly throughout the map. We've also chosen the `mass` of the food to be a random number between 2 and 4 inclusive.
 
-:::csharp
+:::server-csharp
 We also added two helper functions so we can get a random range as either a `uint` or a `float`.
 
 :::
@@ -152,7 +152,7 @@ Although, we've written the reducer to spawn food, no food will actually be spaw
 
 We would like for this function to be called periodically to "top up" the amount of food on the map so that it never falls very far below our target amount of food. SpacetimeDB has built in functionality for exactly this. With SpacetimeDB you can schedule your module to call itself in the future or repeatedly with reducers.
 
-:::rust
+:::server-rust
 In order to schedule a reducer to be called we have to create a new table which specifies when an how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
@@ -167,7 +167,7 @@ pub struct SpawnFoodTimer {
 
 Note the `scheduled(spawn_food)` parameter in the table macro. This tells SpacetimeDB that the rows in this table specify a schedule for when the `spawn_food` reducer should be called. Each scheduled table requires a `scheduled_id` and a `scheduled_at` field so that SpacetimeDB can call your reducer, however you can also add your own fields to these rows as well.
 :::
-:::csharp
+:::server-csharp
 In order to schedule a reducer to be called we have to create a new table which specifies when an how a reducer should be called. Add this new table to the top of the `Module` class.
 
 ```csharp
@@ -187,7 +187,7 @@ You can create, delete, or change a schedule by inserting, deleting, or updating
 
 You will see an error telling you that the `spawn_food` reducer needs to take two arguments, but currently only takes one. This is because the schedule row must be passed in to all scheduled reducers. Modify your `spawn_food` reducer to take the scheduled row as an argument.
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::reducer]
 pub fn spawn_food(ctx: &ReducerContext, _timer: SpawnFoodTimer) -> Result<(), String> {
@@ -195,7 +195,7 @@ pub fn spawn_food(ctx: &ReducerContext, _timer: SpawnFoodTimer) -> Result<(), St
 }
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Reducer]
 public static void SpawnFood(ReducerContext ctx, SpawnFoodTimer _timer)
@@ -207,7 +207,7 @@ public static void SpawnFood(ReducerContext ctx, SpawnFoodTimer _timer)
 
 In our case we aren't interested in the data on the row, so we name the argument `_timer`.
 
-:::rust
+:::server-rust
 Let's modify our `init` reducer to schedule our `spawn_food` reducer to be called every 500 milliseconds.
 
 ```rust
@@ -228,7 +228,7 @@ pub fn init(ctx: &ReducerContext) -> Result<(), String> {
 
 > You can use `ScheduleAt::Interval` to schedule a reducer call at an interval like we're doing here. SpacetimeDB will continue to call the reducer at this interval until you remove the row. You can also use `ScheduleAt::Time()` to specify a specific at which to call a reducer once. SpacetimeDB will remove that row automatically after the reducer has been called.
 :::
-:::csharp
+:::server-csharp
 Let's modify our `Init` reducer to schedule our `SpawnFood` reducer to be called every 500 milliseconds.
 
 ```csharp
@@ -257,12 +257,12 @@ Let's continue building out our server module by modifying it to log in a player
 
 Let's add a second table to our `Player` struct. Modify the `Player` struct by adding this above the struct:
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::table(name = logged_out_player)]
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Table(Name = "logged_out_player")]
 ```
@@ -270,7 +270,7 @@ Let's add a second table to our `Player` struct. Modify the `Player` struct by a
 
 Your struct should now look like this:
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::table(name = player, public)]
 #[spacetimedb::table(name = logged_out_player)]
@@ -285,7 +285,7 @@ pub struct Player {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Table(Name = "player", Public = true)]
 [Table(Name = "logged_out_player")]
@@ -306,7 +306,7 @@ This line creates an additional tabled called `logged_out_player` whose rows sha
 >
 > If your client isn't syncing rows from the server, check that your table is not accidentally marked private.
 
-:::rust
+:::server-rust
 Next, modify your `connect` reducer and add a new `disconnect` reducer below it:
 
 ```rust
@@ -339,7 +339,7 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 Next, modify your `Connect` reducer and add a new `Disconnect` reducer below it:
 
 ```csharp
@@ -387,7 +387,7 @@ When a player disconnects, we will transfer their player row from the `player` t
 
 Now that we've got our food spawning and our players set up, let's create a match and spawn player circle entities into it. The first thing we should do before spawning a player into a match is give them a name. 
 
-:::rust
+:::server-rust
 Add the following to the bottom of your file.
 
 ```rust
@@ -452,7 +452,7 @@ fn spawn_circle_at(
 
 The `enter_game` reducer takes one argument, the player's `name`. We can use this name to display as a label for the player in the match, by storing the name on the player's row. We are also spawning some circles for the player to control now that they are entering the game. To do this, we choose a random position within the bounds of the arena and create a new entity and corresponding circle row.
 :::
-:::csharp
+:::server-csharp
 Add the following to the end of the `Module` class.
 
 ```csharp
@@ -509,7 +509,7 @@ The `EnterGame` reducer takes one argument, the player's `name`. We can use this
 
 Let's also modify our `disconnect` reducer to remove the circles from the arena when the player disconnects from the server.
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::reducer(client_disconnected)]
 pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
@@ -533,7 +533,7 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
 }
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Reducer(ReducerKind.ClientDisconnected)]
 public static void Disconnect(ReducerContext ctx)
@@ -1166,15 +1166,15 @@ Lastly modify the `GameManager.SetupArea` method to set the `WorldSize` on the `
 
 ### Entering the Game
 
-:::rust
+:::server-rust
 At this point, you may need to regenerate your bindings the following command from the `server-rust` directory.
 :::
-:::csharp
+:::server-csharp
 At this point, you may need to regenerate your bindings the following command from the `server-csharp` directory.
 :::
 
 ```sh
-spacetime generate --lang csharp --out-dir ../client/Assets/autogen
+spacetime generate --lang csharp --out-dir ../client-unity/Assets/autogen
 ```
 
 > **BUG WORKAROUND NOTE**: As of `1.0.0-rc3` you will now have a compilation error in Unity. There is currently a bug in the C# code generation that requires you to delete `autogen/LoggedOutPlayer.cs` after running this command.

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -587,7 +587,7 @@ There's still plenty more we can do to build this into a proper game though. For
 - Nice shaders
 - Space theme!
 
-Fortunately, we've done that for you! If you'd like to check out the completed tutorial game you can download it on GitHub:
+Fortunately, we've done that for you! If you'd like to check out the completed tutorial game, with these additional features, you can download it on GitHub:
 
 https://github.com/ClockworkLabs/Blackholio
 

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -8,6 +8,7 @@ This progressive tutorial is continued from [part 3](/docs/unity/part-3).
 
 At this point, we're very close to having a working game. All we have to do is modify our server to allow the player to move around, and to simulate the physics and collisions of the game.
 
+:::rust
 Let's start by building out a simple math library to help us do collision calculations. Create a new `math.rs` file in the `server-rust/src` directory and add the following contents. Let's also move the `DbVector2` type from `lib.rs` into this file.
 
 ```rust
@@ -142,7 +143,7 @@ use math::DbVector2;
 // ...
 ```
 
-Next, add the following table to your `lib.rs` file.
+Next, add the following reducer to your `lib.rs` file.
 
 ```rust
 #[spacetimedb::reducer]
@@ -163,9 +164,58 @@ pub fn update_player_input(ctx: &ReducerContext, direction: DbVector2) -> Result
 ```
 
 This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.sender` value is not set by the client. Instead `ctx.sender` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
+:::
+:::csharp
+Let's start by building out a simple math library to help us do collision calculations. Create a new `Math.cs` file in the `csharp-server` directory and add the following contents. Let's also remove the `DbVector2` type from `Lib.cs`.
+
+```csharp
+[SpacetimeDB.Type]
+public partial struct DbVector2
+{
+    public float x;
+    public float y;
+
+    public DbVector2(float x, float y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+
+    public float SqrMagnitude => x * x + y * y;
+    public float Magnitude => MathF.Sqrt(SqrMagnitude);
+    public DbVector2 Normalized => this / Magnitude;
+
+    public static DbVector2 operator +(DbVector2 a, DbVector2 b) => new DbVector2(a.x + b.x, a.y + b.y);
+    public static DbVector2 operator -(DbVector2 a, DbVector2 b) => new DbVector2(a.x - b.x, a.y - b.y);
+    public static DbVector2 operator *(DbVector2 a, float b) => new DbVector2(a.x * b, a.y * b);
+    public static DbVector2 operator /(DbVector2 a, float b) => new DbVector2(a.x / b, a.y / b);
+}
+```
+
+Next, add the following reducer to the `Module` class of your `Lib.cs` file.
+
+```csharp
+[Reducer]
+public static void UpdatePlayerInput(ReducerContext ctx, DbVector2 direction)
+{
+    var player = ctx.Db.player.identity.Find(ctx.CallerIdentity) ?? throw new Exception("Player not found");				
+    foreach (var c in ctx.Db.circle.player_id.Filter(player.player_id))
+    {
+        var circle = c;
+        circle.direction = direction.Normalized;
+        circle.speed = Math.Clamp(direction.Magnitude, 0f, 1f);
+        ctx.Db.circle.entity_id.Update(circle);
+    }
+		  
+}
+```
+
+This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.CallerIdentity` value is not set by the client. Instead `ctx.CallerIdentity` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
+:::
 
 Finally, let's schedule a reducer to run every 50 milliseconds to move the player's circles around based on the most recently set player input.
 
+:::rust
 ```rust
 #[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
@@ -208,11 +258,48 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
     Ok(())
 }
 ```
+:::
+:::csharp
+```csharp
+[Table(Name = "move_all_players_timer", Scheduled = nameof(MoveAllPlayers), ScheduledAt = "scheduled_at")]
+public partial struct MoveAllPlayersTimer
+{
+    [PrimaryKey, AutoInc]
+    public ulong scheduled_id;
+    public ScheduleAt scheduled_at;
+}
+
+const uint START_PLAYER_SPEED = 10;
+
+public static float MassToMaxMoveSpeed(uint mass) => 2f * START_PLAYER_SPEED / (1f + MathF.Sqrt((float)mass / START_PLAYER_MASS));
+
+[Reducer]
+public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
+{
+    var world_size = (ctx.Db.config.id.Find(0) ?? throw new Exception("Config not found")).world_size;
+
+    var circle_directions = ctx.Db.circle.Iter().Select(c => (c.entity_id, c.direction * c.speed)).ToDictionary();
+
+    //Handle player input
+    foreach (var circle in ctx.Db.circle.Iter())
+    {
+        var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Circle has no entity");
+        var circle_radius = MassToRadius(circle_entity.mass);
+        var direction = circle_directions[circle.entity_id];
+        var new_pos = circle_entity.position + direction * MassToMaxMoveSpeed(circle_entity.mass);
+        circle_entity.position.x = Math.Clamp(new_pos.x, circle_radius, world_size - circle_radius);
+        circle_entity.position.y = Math.Clamp(new_pos.y, circle_radius, world_size - circle_radius);
+        ctx.Db.entity.entity_id.Update(circle_entity);
+    }
+}
+```
+:::
 
 This reducer is very similar to a standard game "tick" or "frame" that you might find in an ordinary game server or similar to something like the `Update` loop in a game engine like Unity. We've scheduled it every 50 milliseconds and we can use it to step forward our simulation by moving all the circles a little bit further in the direction they're moving.
 
 In this reducer, we're just looping through all the circles in the game and updating their position based on their direction, speed, and mass. Just basic physics.
 
+:::rust
 Add the following to your `init` reducer to schedule the `move_all_players` reducer to run every 50 milliseconds.
 
 ```rust
@@ -223,6 +310,18 @@ Add the following to your `init` reducer to schedule the `move_all_players` redu
             scheduled_at: ScheduleAt::Interval(Duration::from_millis(50).as_micros() as u64),
         })?;
 ```
+:::
+:::csharp
+Add the following to your `Init` reducer to schedule the `MoveAllPlayers` reducer to run every 50 milliseconds.
+
+```csharp
+ctx.Db.move_all_players_timer.Insert(new MoveAllPlayersTimer
+{
+    scheduled_at = new ScheduleAt.Interval(TimeSpan.FromMilliseconds(50))
+});
+```
+:::
+
 
 Republish your module with:
 
@@ -288,9 +387,10 @@ Let's try it out! Press play and roam freely around the arena! Now we're cooking
 
 Well this is pretty fun, but wouldn't it be better if we could eat food and grow our circle? Surely, that's going to be a pain, right?
 
+:::rust
 Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `is_overlapping` helper function which does some basic math based on mass radii, and modify our `move_all_player` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
 
-Sometimes simple is best!
+Sometimes simple is best! Add the following code to your `lib.rs` file.
 
 ```rust
 const MINIMUM_SAFE_MASS_RATIO: f32 = 0.85;
@@ -366,6 +466,86 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
     Ok(())
 }
 ```
+:::
+:::csharp
+Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `IsOverlapping` helper function which does some basic math based on mass radii, and modify our `MoveAllPlayers` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
+
+Sometimes simple is best! Add the following code to the `Module` class of your `Lib.cs` file.
+
+```csharp
+ const float MINIMUM_SAFE_MASS_RATIO = 0.85f;
+
+public static bool IsOverlapping(Entity a, Entity b)
+{
+    var dx = a.position.x - b.position.x;
+    var dy = a.position.y - b.position.y;
+    var distance_sq = dx * dx + dy * dy;
+
+    var radius_a = MassToRadius(a.mass);
+    var radius_b = MassToRadius(b.mass);
+    
+    // If the distance between the two circle centers is less than the
+    // maximum radius, then the center of the smaller circle is inside
+    // the larger circle. This gives some leeway for the circles to overlap
+    // before being eaten.
+    var max_radius = radius_a > radius_b ? radius_a: radius_b;
+    return distance_sq <= max_radius * max_radius;
+}
+
+[Reducer]
+public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
+{
+    //var span = new SpacetimeDB.LogStopwatch("tick");
+    var world_size = (ctx.Db.config.id.Find(0) ?? throw new Exception("Config not found")).world_size;
+
+    //Handle player input
+    foreach (var circle in ctx.Db.circle.Iter())
+    {
+        var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Circle has no entity");
+        var circle_radius = MassToRadius(circle_entity.mass);
+        var direction = circle.direction * circle.speed;
+        var new_pos = circle_entity.position + direction * MassToMaxMoveSpeed(circle_entity.mass);
+        circle_entity.position.x = Math.Clamp(new_pos.x, circle_radius, world_size - circle_radius);
+        circle_entity.position.y = Math.Clamp(new_pos.y, circle_radius, world_size - circle_radius);
+        
+
+        // Check collisions
+        foreach (var entity in ctx.Db.entity.Iter())
+        {
+            if (entity.entity_id == circle_entity.entity_id)
+            {
+                continue;
+            }
+            if (IsOverlapping(circle_entity, entity))
+            {
+                // Check to see if we're overlapping with food
+                if (ctx.Db.food.entity_id.Find(entity.entity_id).HasValue) {
+                    ctx.Db.entity.entity_id.Delete(entity.entity_id);
+                    ctx.Db.food.entity_id.Delete(entity.entity_id);
+                    circle_entity.mass += entity.mass;
+                }
+                
+                // Check to see if we're overlapping with another circle owned by another player
+                var other_circle = ctx.Db.circle.entity_id.Find(entity.entity_id);
+                if (other_circle.HasValue &&
+                    other_circle.Value.player_id != circle.player_id)
+                {
+                    var mass_ratio = (float)entity.mass / circle_entity.mass;
+                    if (mass_ratio < MINIMUM_SAFE_MASS_RATIO)
+                    {
+                        ctx.Db.entity.entity_id.Delete(entity.entity_id);
+                        ctx.Db.circle.entity_id.Delete(entity.entity_id);
+                        circle_entity.mass += entity.mass;
+                    }
+                }
+            }
+        }
+        ctx.Db.entity.entity_id.Update(circle_entity);
+    }
+}
+```
+:::
+
 
 For every circle, we look at all other entities. If they are overlapping then for food, we add the mass of the food to the circle and delete the food, otherwise if it's a circle we delete the smaller circle and add the mass to the bigger circle.
 
@@ -383,7 +563,12 @@ Notice that the food automatically respawns as you vaccuum them up. This is beca
 
 # Conclusion
 
+:::rust
 So far you've learned how to configure a new Unity project to work with SpacetimeDB, how to develop, build, and publish a SpacetimeDB server module. Within the module, you've learned how to create tables, update tables, and write reducers. You've learned about special reducers like `client_connected` and `init` and how to created scheduled reducers. You learned how we can used scheduled reducers to implement a physics simulation right within your module.
+:::
+:::csharp
+So far you've learned how to configure a new Unity project to work with SpacetimeDB, how to develop, build, and publish a SpacetimeDB server module. Within the module, you've learned how to create tables, update tables, and write reducers. You've learned about special reducers like `ClientConnected` and `Init` and how to created scheduled reducers. You learned how we can used scheduled reducers to implement a physics simulation right within your module.
+:::
 
 You've also learned how view module logs and connect your client to your server module, call reducers from the client and synchronize the data with client. Finally you learned how to use that synchronized data to draw game objects on the screen, so that we can interact with them and play a game!
 

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -261,7 +261,7 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
 :::
 :::server-csharp
 ```csharp
-[Table(Name = "move_all_players_timer", Scheduled = nameof(MoveAllPlayers), ScheduledAt = "scheduled_at")]
+[Table(Name = "move_all_players_timer", Scheduled = nameof(MoveAllPlayers), ScheduledAt = nameof(scheduled_at))]
 public partial struct MoveAllPlayersTimer
 {
     [PrimaryKey, AutoInc]
@@ -303,12 +303,12 @@ In this reducer, we're just looping through all the circles in the game and upda
 Add the following to your `init` reducer to schedule the `move_all_players` reducer to run every 50 milliseconds.
 
 ```rust
-    ctx.db
-        .move_all_players_timer()
-        .try_insert(MoveAllPlayersTimer {
-            scheduled_id: 0,
-            scheduled_at: ScheduleAt::Interval(Duration::from_millis(50).as_micros() as u64),
-        })?;
+ctx.db
+    .move_all_players_timer()
+    .try_insert(MoveAllPlayersTimer {
+        scheduled_id: 0,
+        scheduled_at: ScheduleAt::Interval(Duration::from_millis(50).as_micros() as u64),
+    })?;
 ```
 :::
 :::server-csharp
@@ -332,7 +332,7 @@ spacetime publish --server local blackholio --delete-data
 Regenerate your server bindings with:
 
 ```sh
-spacetime generate --lang csharp --out-dir ../client/Assets/autogen
+spacetime generate --lang csharp --out-dir ../client-unity/Assets/autogen
 ```
 
 > **BUG WORKAROUND NOTE**: You may have to delete LoggedOutPlayer.cs again.
@@ -473,7 +473,7 @@ Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `IsOver
 Sometimes simple is best! Add the following code to the `Module` class of your `Lib.cs` file.
 
 ```csharp
- const float MINIMUM_SAFE_MASS_RATIO = 0.85f;
+const float MINIMUM_SAFE_MASS_RATIO = 0.85f;
 
 public static bool IsOverlapping(Entity a, Entity b)
 {
@@ -507,7 +507,6 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
         var new_pos = circle_entity.position + direction * MassToMaxMoveSpeed(circle_entity.mass);
         circle_entity.position.x = Math.Clamp(new_pos.x, circle_radius, world_size - circle_radius);
         circle_entity.position.y = Math.Clamp(new_pos.y, circle_radius, world_size - circle_radius);
-        
 
         // Check collisions
         foreach (var entity in ctx.Db.entity.Iter())

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -8,7 +8,7 @@ This progressive tutorial is continued from [part 3](/docs/unity/part-3).
 
 At this point, we're very close to having a working game. All we have to do is modify our server to allow the player to move around, and to simulate the physics and collisions of the game.
 
-:::rust
+:::server-rust
 Let's start by building out a simple math library to help us do collision calculations. Create a new `math.rs` file in the `server-rust/src` directory and add the following contents. Let's also move the `DbVector2` type from `lib.rs` into this file.
 
 ```rust
@@ -165,7 +165,7 @@ pub fn update_player_input(ctx: &ReducerContext, direction: DbVector2) -> Result
 
 This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.sender` value is not set by the client. Instead `ctx.sender` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
 :::
-:::csharp
+:::server-csharp
 Let's start by building out a simple math library to help us do collision calculations. Create a new `Math.cs` file in the `csharp-server` directory and add the following contents. Let's also remove the `DbVector2` type from `Lib.cs`.
 
 ```csharp
@@ -215,7 +215,7 @@ This is a simple reducer that takes the movement input from the client and appli
 
 Finally, let's schedule a reducer to run every 50 milliseconds to move the player's circles around based on the most recently set player input.
 
-:::rust
+:::server-rust
 ```rust
 #[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
@@ -259,7 +259,7 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
 }
 ```
 :::
-:::csharp
+:::server-csharp
 ```csharp
 [Table(Name = "move_all_players_timer", Scheduled = nameof(MoveAllPlayers), ScheduledAt = "scheduled_at")]
 public partial struct MoveAllPlayersTimer
@@ -299,7 +299,7 @@ This reducer is very similar to a standard game "tick" or "frame" that you might
 
 In this reducer, we're just looping through all the circles in the game and updating their position based on their direction, speed, and mass. Just basic physics.
 
-:::rust
+:::server-rust
 Add the following to your `init` reducer to schedule the `move_all_players` reducer to run every 50 milliseconds.
 
 ```rust
@@ -311,7 +311,7 @@ Add the following to your `init` reducer to schedule the `move_all_players` redu
         })?;
 ```
 :::
-:::csharp
+:::server-csharp
 Add the following to your `Init` reducer to schedule the `MoveAllPlayers` reducer to run every 50 milliseconds.
 
 ```csharp
@@ -387,7 +387,7 @@ Let's try it out! Press play and roam freely around the arena! Now we're cooking
 
 Well this is pretty fun, but wouldn't it be better if we could eat food and grow our circle? Surely, that's going to be a pain, right?
 
-:::rust
+:::server-rust
 Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `is_overlapping` helper function which does some basic math based on mass radii, and modify our `move_all_player` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
 
 Sometimes simple is best! Add the following code to your `lib.rs` file.
@@ -467,7 +467,7 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
 }
 ```
 :::
-:::csharp
+:::server-csharp
 Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `IsOverlapping` helper function which does some basic math based on mass radii, and modify our `MoveAllPlayers` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
 
 Sometimes simple is best! Add the following code to the `Module` class of your `Lib.cs` file.
@@ -563,10 +563,10 @@ Notice that the food automatically respawns as you vaccuum them up. This is beca
 
 # Conclusion
 
-:::rust
+:::server-rust
 So far you've learned how to configure a new Unity project to work with SpacetimeDB, how to develop, build, and publish a SpacetimeDB server module. Within the module, you've learned how to create tables, update tables, and write reducers. You've learned about special reducers like `client_connected` and `init` and how to created scheduled reducers. You learned how we can used scheduled reducers to implement a physics simulation right within your module.
 :::
-:::csharp
+:::server-csharp
 So far you've learned how to configure a new Unity project to work with SpacetimeDB, how to develop, build, and publish a SpacetimeDB server module. Within the module, you've learned how to create tables, update tables, and write reducers. You've learned about special reducers like `ClientConnected` and `Init` and how to created scheduled reducers. You learned how we can used scheduled reducers to implement a physics simulation right within your module.
 :::
 

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -280,7 +280,7 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 
     var circle_directions = ctx.Db.circle.Iter().Select(c => (c.entity_id, c.direction * c.speed)).ToDictionary();
 
-    //Handle player input
+    // Handle player input
     foreach (var circle in ctx.Db.circle.Iter())
     {
         var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Circle has no entity");
@@ -390,7 +390,7 @@ Well this is pretty fun, but wouldn't it be better if we could eat food and grow
 :::server-rust
 Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `is_overlapping` helper function which does some basic math based on mass radii, and modify our `move_all_player` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
 
-Sometimes simple is best! Add the following code to your `lib.rs` file.
+Sometimes simple is best! Add the following code to your `lib.rs` file and make sure to replace the existing `move_all_players` reducer.
 
 ```rust
 const MINIMUM_SAFE_MASS_RATIO: f32 = 0.85;
@@ -470,7 +470,7 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
 :::server-csharp
 Wrong. With SpacetimeDB it's extremely easy. All we have to do is add an `IsOverlapping` helper function which does some basic math based on mass radii, and modify our `MoveAllPlayers` reducer to loop through every entity in the arena for every circle, checking each for overlaps. This may not be the most efficient way to do collision checking (building a quad tree or doing [spatial hashing](https://conkerjo.wordpress.com/2009/06/13/spatial-hashing-implementation-for-fast-2d-collisions/) might be better), but SpacetimeDB is very fast so for this number of entities it'll be a breeze for SpacetimeDB.
 
-Sometimes simple is best! Add the following code to the `Module` class of your `Lib.cs` file.
+Sometimes simple is best! Add the following code to the `Module` class of your `Lib.cs` file and make sure to replace the existing `MoveAllPlayers` reducer.
 
 ```csharp
 const float MINIMUM_SAFE_MASS_RATIO = 0.85f;
@@ -495,10 +495,9 @@ public static bool IsOverlapping(Entity a, Entity b)
 [Reducer]
 public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 {
-    //var span = new SpacetimeDB.LogStopwatch("tick");
     var world_size = (ctx.Db.config.id.Find(0) ?? throw new Exception("Config not found")).world_size;
 
-    //Handle player input
+    // Handle player input
     foreach (var circle in ctx.Db.circle.Iter())
     {
         var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Circle has no entity");


### PR DESCRIPTION
Adds C# Server implementation instructions to the existing tutorial, and separates out these instructions such that:
:::server-rust
A rust server implementation section.
:::
:::server-csharp
A csharp server implementation section.
:::
By leveraging the changes in https://github.com/clockworklabs/spacetime-web/pull/497, markdown page contents between :::server-rust and the subsequent ::: will be hidden unless "Rust" is selected as the language the server should be written in. The same is true for :::server-csharp sections remaining hidden unless "C#" is selected as the language the server should be written in.