### PR TITLE
Updated the TypeScript quickstart guide to use the new 1.0 API

### DIFF
--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -17,7 +17,7 @@ Enter the directory `quickstart-chat` you created in the [Rust Module Quickstart
 cd quickstart-chat
 ```
 
-Within it, create a `client` react app:
+Within it, create a `client` React app:
 
 ```bash
 pnpm create vite@latest client -- --template react-ts

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -31,7 +31,7 @@ We also need to install the `spacetime-client-sdk` package:
 pnpm install @clockworklabs/spacetimedb-sdk@1.0.0-rc1.0
 ```
 
-> If you are using another package manager like `yarn` or `npm` the same steps should work with the appropriate commands for those tools.
+> If you are using another package manager like `yarn` or `npm`, the same steps should work with the appropriate commands for those tools.
 
 If you like, you can now run `pnpm run dev` to see the vite template app running at `http://localhost:5173`.
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -366,7 +366,7 @@ mkdir -p client/src/module_bindings
 spacetime generate --lang typescript --out-dir client/src/module_bindings --project-path server
 ```
 
-> This command assumes you've already created a server module in `quickstart-chat/server`. If you haven't, go follow either the [Rust](/docs/modules/rust/quickstart) or [C#](/docs/modules/c-sharp/quickstart) module quickstart, then come back here.
+> This command assumes you've already created a server module in `quickstart-chat/server`. If you haven't completed one of the server module quickstart guides, you can follow either the [Rust](/docs/modules/rust/quickstart) or [C#](/docs/modules/c-sharp/quickstart) module quickstart to create one and then return here.
 
 Take a look inside `client/src/module_bindings`. The CLI should have generated several files:
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -366,7 +366,7 @@ mkdir -p client/src/module_bindings
 spacetime generate --lang typescript --out-dir client/src/module_bindings --project-path server
 ```
 
-> This command assumes you've already created a server module in `quickstart-chat/server`.
+> This command assumes you've already created a server module in `quickstart-chat/server`. If you haven't, go follow either the [Rust](/docs/modules/rust/quickstart) or [C#](/docs/modules/c-sharp/quickstart) module quickstart, then come back here.
 
 Take a look inside `client/src/module_bindings`. The CLI should have generated several files:
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -1,8 +1,8 @@
 # TypeScript Client SDK Quickstart
 
-In this guide, you'll learn how to use TypeScript to create a SpacetimeDB client application. While we currently support TypeScript as a client language, we do not yet support writing SpacetimeDB server modules in TypeScript.
+In this guide, you'll learn how to use TypeScript to create a SpacetimeDB client application.
 
-**Before you get started on this guide**, you should complete one of the quickstart guides for creating a SpacetimeDB server module listed below.
+Please note that TypeScript is supported as a client language only. **Before you get started on this guide**, you should complete one of the quickstart guides for creating a SpacetimeDB server module listed below.
 
 - [Rust](/docs/modules/rust/quickstart)
 - [C#](/docs/modules/c-sharp/quickstart)
@@ -68,13 +68,13 @@ function App() {
   const onSubmitNewName = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSettingName(false);
-    conn.reducers.setName(newName);
+    // TODO: Call `setName` reducer
   };
 
   const onMessageSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setNewMessage('');
-    conn.reducers.sendMessage(newMessage);
+    // TODO: Call `sendMessage` reducer
   };
 
   return (

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -393,7 +393,7 @@ import { Identity } from '@clockworklabs/spacetimedb-sdk';
 
 ## Create your SpacetimeDB client
 
-Now that we've imported the `DBConnection` type we can use it to connect our app to our module.
+Now that we've imported the `DBConnection` type, we can use it to connect our app to our module.
 
 Add the following to your `App` function, just below `const [newMessage, setNewMessage] = useState("");`:
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -447,7 +447,7 @@ Add the following to your `App` function, just below `const [newMessage, setNewM
 
 Here we are configuring our SpacetimeDB connection by specifying the server URI, module name, and a few callbacks including the `onConnect` callback. When `onConnect` is called after connecting, we store the connection state, our `Identity`, and our SpacetimeDB credentials in our React state. If there is an error connecting, we print that error to the console as well.
 
-We are also using `localStorage` to store our SpacetimeDB credentials. This way, we can reconnect to SpacetimeDB with the same `Identity` and token if we refresh the page. The first time we connect, we won't have any credentials stored, so we pass `undefined` to the `withToken` method, this will cause SpacetimeDB to generate new credentials for us.
+We are also using `localStorage` to store our SpacetimeDB credentials. This way, we can reconnect to SpacetimeDB with the same `Identity` and token if we refresh the page. The first time we connect, we won't have any credentials stored, so we pass `undefined` to the `withToken` method. This will cause SpacetimeDB to generate new credentials for us.
 
 If you chose a different name for your module, replace `quickstart-chat` with that name, or republish your module as `quickstart-chat`.
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -451,7 +451,7 @@ We are also using `localStorage` to store our SpacetimeDB credentials. This way,
 
 If you chose a different name for your module, replace `quickstart-chat` with that name, or republish your module as `quickstart-chat`.
 
-In the `onConnect` function we are also subscribing to the `message` and `user` tables. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "SDK client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
+In the `onConnect` function we are also subscribing to the `message` and `user` tables. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
 
 ### Accessing the Data
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -33,7 +33,7 @@ pnpm install @clockworklabs/spacetimedb-sdk@1.0.0-rc1.0
 
 > If you are using another package manager like `yarn` or `npm`, the same steps should work with the appropriate commands for those tools.
 
-If you like, you can now run `pnpm run dev` to see the vite template app running at `http://localhost:5173`.
+You can now `pnpm run dev` to see the Vite template app running at `http://localhost:5173`.
 
 ## Basic layout
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -5,7 +5,7 @@ In this guide, you'll learn how to use TypeScript to create a SpacetimeDB client
 **Before you get started on this guide**, you should complete one of the quickstart guides for creating a SpacetimeDB server module listed below.
 
 - [Rust](/docs/modules/rust/quickstart)
-- [C#](/docs/modules/csharp/quickstart)
+- [C#](/docs/modules/c-sharp/quickstart)
 
 By the end of this introduciton, you will have created a basic single page web app for the module created in the above module quickstart guides.
 
@@ -47,8 +47,8 @@ The app we're going to create is a basic chat application. We are going to start
 Replace the entire contents of `client/src/App.tsx` with the following:
 
 ```tsx
-import React, { useEffect, useState } from "react";
-import "./App.css";
+import React, { useEffect, useState } from 'react';
+import './App.css';
 
 export type PrettyMessage = {
   senderName: string;
@@ -56,28 +56,29 @@ export type PrettyMessage = {
 };
 
 function App() {
-  const [newName, setNewName] = useState("");
+  const [newName, setNewName] = useState('');
   const [settingName, setSettingName] = useState(false);
-  const [name, setName] = useState("");
-  const [systemMessage, setSystemMessage] = useState("");
-  const [newMessage, setNewMessage] = useState("");
+  const [systemMessage, setSystemMessage] = useState('');
+  const [newMessage, setNewMessage] = useState('');
 
   const prettyMessages: PrettyMessage[] = [];
+
+  const name = '';
 
   const onSubmitNewName = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setSettingName(false);
-    // Fill in app logic here
+    conn.reducers.setName(newName);
   };
 
-  const onSubmitMessage = (e: React.FormEvent<HTMLFormElement>) => {
+  const onMessageSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setNewMessage("");
-    // Fill in app logic here
+    setNewMessage('');
+    conn.reducers.sendMessage(newMessage);
   };
 
   return (
-    <div className="app">
+    <div className="App">
       <div className="profile">
         <h1>Profile</h1>
         {!settingName ? (
@@ -96,9 +97,8 @@ function App() {
           <form onSubmit={onSubmitNewName}>
             <input
               type="text"
-              style={{ marginBottom: "1rem" }}
               value={newName}
-              onChange={(e) => setNewName(e.target.value)}
+              onChange={e => setNewName(e.target.value)}
             />
             <button type="submit">Submit</button>
           </form>
@@ -118,7 +118,7 @@ function App() {
           ))}
         </div>
       </div>
-      <div className="system" style={{ whiteSpace: "pre-wrap" }}>
+      <div className="system" style={{ whiteSpace: 'pre-wrap' }}>
         <h1>System</h1>
         <div>
           <p>{systemMessage}</p>
@@ -126,18 +126,18 @@ function App() {
       </div>
       <div className="new-message">
         <form
-          onSubmit={onSubmitMessage}
+          onSubmit={onMessageSubmit}
           style={{
-            display: "flex",
-            flexDirection: "column",
-            width: "50%",
-            margin: "0 auto",
+            display: 'flex',
+            flexDirection: 'column',
+            width: '50%',
+            margin: '0 auto',
           }}
         >
           <h3>New Message</h3>
           <textarea
             value={newMessage}
-            onChange={(e) => setNewMessage(e.target.value)}
+            onChange={e => setNewMessage(e.target.value)}
           ></textarea>
           <button type="submit">Send</button>
         </form>
@@ -150,6 +150,208 @@ export default App;
 ```
 
 We have configured the `onSubmitNewName` and `onSubmitMessage` callbacks to be called when the user clicks the submit button in the profile and new message sections, respectively. For now, they do nothing when called, but later we'll add some logic to call SpacetimeDB reducers when these callbacks are called.
+
+Let's also make it pretty. Replace the contents of `client/src/App.css` with the following:
+
+```css
+.App {
+  display: grid;
+  /* 
+    3 rows: 
+      1) Profile
+      2) Main content (left = message, right = system)
+      3) New message
+  */
+  grid-template-rows: auto 1fr auto;
+  /* 2 columns: left for chat, right for system */
+  grid-template-columns: 2fr 1fr;
+
+  height: 100vh; /* fill viewport height */
+  width: clamp(300px, 100%, 1200px);
+  margin: 0 auto;
+}
+
+/* ----- Profile (Row 1, spans both columns) ----- */
+.profile {
+  grid-column: 1 / 3;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--theme-color);
+}
+
+.profile h1 {
+  margin-right: auto; /* pushes name/edit form to the right */
+}
+
+.profile form {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 300px;
+}
+
+.profile form input {
+  background-color: var(--textbox-color);
+}
+
+/* ----- Chat Messages (Row 2, Col 1) ----- */
+.message {
+  grid-row: 2 / 3;
+  grid-column: 1 / 2;
+  
+  /* Ensure this section scrolls if content is long */
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message h1 {
+  margin-right: 0.5rem;
+}
+
+/* ----- System Panel (Row 2, Col 2) ----- */
+.system {
+  grid-row: 2 / 3;
+  grid-column: 2 / 3;
+
+  /* Also scroll independently if needed */
+  overflow-y: auto;
+  padding: 1rem;
+  border-left: 1px solid var(--theme-color);
+  white-space: pre-wrap;
+  font-family: monospace;
+}
+
+/* ----- New Message (Row 3, spans columns 1-2) ----- */
+.new-message {
+  grid-column: 1 / 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  border-top: 1px solid var(--theme-color);
+}
+
+.new-message form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 600px;
+}
+
+.new-message form h3 {
+  margin-bottom: 0.25rem;
+}
+
+/* Distinct background for the textarea */
+.new-message form textarea {
+  font-family: monospace;
+  font-weight: 400;
+  font-size: 1rem;
+  resize: vertical;
+  min-height: 80px;
+  background-color: var(--textbox-color);
+  color: inherit;
+
+  /* Subtle shadow for visibility */
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.24);
+}
+
+@media (prefers-color-scheme: dark) {
+  .new-message form textarea {
+    box-shadow: 0 0 0 1px #17492b;
+  }
+}
+```
+
+Next we need to replace the global styles in `client/src/index.css` as well:
+
+```css
+/* ----- CSS Reset & Global Settings ----- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ----- Color Variables ----- */
+:root {
+  --theme-color: #3dc373;
+  --theme-color-contrast: #08180e;
+  --textbox-color: #edfef4;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-color: #4cf490;
+    --theme-color-contrast: #132219;
+    --textbox-color: #0f311d;
+  }
+}
+
+/* ----- Page Setup ----- */
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
+}
+
+/* ----- Buttons ----- */
+button {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 0.375rem;
+  background-color: var(--theme-color);
+  color: var(--theme-color-contrast);
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  font-family: monospace;
+}
+
+/* ----- Inputs & Textareas ----- */
+input,
+textarea {
+  border: none;
+  border-radius: 0.375rem;
+  caret-color: var(--theme-color);
+  font-family: monospace;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  padding: 0.5rem 0.75rem;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--theme-color);
+}
+```
 
 Now when you run `pnpm run dev` and open `http://localhost:5173`, you should see a basic chat app that does not yet send or receive messages.
 
@@ -185,7 +387,7 @@ module_bindings
 With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. The main entry to the SpacetimeDB API is via the `DBConnection` which was generated into the `module_bindings` folder. Let's import it and a few other types into our `client/src/App.tsx`.
 
 ```tsx
-import { DBConnection } from './module_bindings';
+import { DBConnection, EventContext, Message, User } from './module_bindings';
 import { Identity } from '@clockworklabs/spacetimedb-sdk';
 ```
 
@@ -193,75 +395,63 @@ import { Identity } from '@clockworklabs/spacetimedb-sdk';
 
 Now that we've imported the `DBConnection` type we can use it to connect our app to our module.
 
-Add the following `App` function, just below `const [newMessage, setNewMessage] = useState("");`:
+Add the following to your `App` function, just below `const [newMessage, setNewMessage] = useState("");`:
 
 ```tsx
   const [connected, setConnected] = useState<boolean>(false);
   const [identity, setIdentity] = useState<Identity | null>(null);
+  const [conn, setConn] = useState<DBConnection | null>(null);
 
-  const [conn] = useState(DBConnection.builder()
-      .withUri('ws://localhost:3000')
-      .withModuleName('quickstart-chat')
-      .onConnect((conn, identity, token) => {
-        setIdentity(identity);
-        setConnected(true);
+  useEffect(() => {
+    const onConnect = (
+      conn: DBConnection,
+      identity: Identity,
+      token: string
+    ) => {
+      setIdentity(identity);
+      setConnected(true);
+      localStorage.setItem('auth_token', token);
+      console.log(
+        'Connected to SpacetimeDB with identity:',
+        identity.toHexString()
+      );
+      conn
+        .subscriptionBuilder()
+        .onApplied(() => {
+          console.log('SDK client cache initialized.');
+        })
+        .subscribe(['SELECT * FROM message', 'SELECT * FROM user']);
+    };
 
-        console.log("Connected to SpacetimeDB with identity:", identity.toHexString());
+    const onDisconnect = () => {
+      console.log('Disconnected from SpacetimeDB');
+      setConnected(false);
+    };
 
-        // Subscribe to the `message` table.
-        conn.subscriptionBuilder().onApplied(() => {
-          console.log("SDK client cache initialized.");
-        }).subscribe(['SELECT * FROM message']);
-      })
-      .onConnectError((_conn, err) => {
-        console.error("Error connecting to SpacetimeDB:", err);
-      })
-      .onDisconnect(() => {
-        console.log("Disconnected from SpacetimeDB");
-        setConnected(false);
-      })
-      .build()
-  );
+    const onConnectError = (_conn: DBConnection, err: Error) => {
+      console.log('Error connecting to SpacetimeDB:', err);
+    };
+
+    setConn(
+      DBConnection.builder()
+        .withUri('ws://localhost:3000')
+        .withModuleName('quickstart-chat')
+        .withToken(localStorage.getItem('auth_token') || '')
+        .onConnect(onConnect)
+        .onDisconnect(onDisconnect)
+        .onConnectError(onConnectError)
+        .build()
+    );
+  }, []);
 ```
 
-Here we are configuring our SpacetimeDB connection by specifying the server URI, module name, and an `onConnect` callback. When `onConnect` is called after connecting, we store the connection state, our `Identity`, and our SpacetimeDB credentials in our React state. If there is an error connecting, we print that error to the console as well.
+Here we are configuring our SpacetimeDB connection by specifying the server URI, module name, and a few callbacks including the `onConnect` callback. When `onConnect` is called after connecting, we store the connection state, our `Identity`, and our SpacetimeDB credentials in our React state. If there is an error connecting, we print that error to the console as well.
+
+We are also using `localStorage` to store our SpacetimeDB credentials. This way, we can reconnect to SpacetimeDB with the same `Identity` and token if we refresh the page. The first time we connect, we won't have any credentials stored, so we pass `undefined` to the `withToken` method, this will cause SpacetimeDB to generate new credentials for us.
 
 If you chose a different name for your module, replace `quickstart-chat` with that name, or republish your module as `quickstart-chat`.
 
-In this case, we are not connecting to SpacetimeDB with pre-existing credentials so SpacetimeDB is assigning us a new `Identity` and token on connection. In order to connect to SpacetimeDB as the same user after refreshing, let's store the credentials in `localStorage` and pass them in when connecting. Modify your code with the following:
-
-```tsx
-  const [connected, setConnected] = useState<boolean>(false);
-  const [identity, setIdentity] = useState<Identity | null>(null);
-
-  const [conn] = useState(DBConnection.builder()
-      .withUri('ws://localhost:3000')
-      .withModuleName('quickstart-chat')
-      .withToken(localStorage.getItem('auth_token') || undefined)
-      .onConnect((conn, identity, token) => {
-        setIdentity(identity);
-        setConnected(true);
-        localStorage.setItem('auth_token', token);
-
-        console.log("Connected to SpacetimeDB with identity:", identity.toHexString());
-
-        // Subscribe to the `message` table.
-        conn.subscriptionBuilder().onApplied(() => {
-          console.log("SDK client cache initialized.");
-        }).subscribe(['SELECT * FROM message']);
-      })
-      .onConnectError((_conn, err) => {
-        console.error("Error connecting to SpacetimeDB:", err);
-      })
-      .onDisconnect(() => {
-        console.log("Disconnected from SpacetimeDB");
-        setConnected(false);
-      })
-      .build()
-  );
-```
-
-In the `onConnect` function we are also subscribing to the `message` table. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "SDK client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
+In the `onConnect` function we are also subscribing to the `message` and `user` tables. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "SDK client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
 
 ### Accessing the Data
 
@@ -270,17 +460,25 @@ Once SpacetimeDB is connected, we can easily access the data inside of the clien
 Let's create custom React hooks for the `message` and `user` tables. Add the following code above your `App` component:
 
 ```tsx
-function useMessages(conn: DBConnection): Message[] {
+function useMessages(conn: DBConnection | null): Message[] {
   const [messages, setMessages] = useState<Message[]>([]);
 
   useEffect(() => {
+    if (!conn) return;
     const onInsert = (_ctx: EventContext, message: Message) => {
-      setMessages((prev) => [...prev, message]);
+      setMessages(prev => [...prev, message]);
     };
     conn.db.message.onInsert(onInsert);
 
     const onDelete = (_ctx: EventContext, message: Message) => {
-      setMessages((prev) => prev.filter((m) => m.text !== message.text && m.sent !== message.sent && m.sender !== message.sender));
+      setMessages(prev =>
+        prev.filter(
+          m =>
+            m.text !== message.text &&
+            m.sent !== message.sent &&
+            m.sender !== message.sender
+        )
+      );
     };
     conn.db.message.onDelete(onDelete);
 
@@ -293,17 +491,18 @@ function useMessages(conn: DBConnection): Message[] {
   return messages;
 }
 
-function useUsers(conn: DBConnection): Map<string, User> {
+function useUsers(conn: DBConnection | null): Map<string, User> {
   const [users, setUsers] = useState<Map<string, User>>(new Map());
 
   useEffect(() => {
+    if (!conn) return;
     const onInsert = (_ctx: EventContext, user: User) => {
-      setUsers((prev) => new Map(prev.set(user.identity.toHexString(), user)));
+      setUsers(prev => new Map(prev.set(user.identity.toHexString(), user)));
     };
     conn.db.user.onInsert(onInsert);
 
     const onUpdate = (_ctx: EventContext, oldUser: User, newUser: User) => {
-      setUsers((prev) => {
+      setUsers(prev => {
         prev.delete(oldUser.identity.toHexString());
         return new Map(prev.set(newUser.identity.toHexString(), newUser));
       });
@@ -311,7 +510,7 @@ function useUsers(conn: DBConnection): Map<string, User> {
     conn.db.user.onUpdate(onUpdate);
 
     const onDelete = (_ctx: EventContext, user: User) => {
-      setUsers((prev) => {
+      setUsers(prev => {
         prev.delete(user.identity.toHexString());
         return new Map(prev);
       });
@@ -333,21 +532,48 @@ These custom React hooks update the React state anytime a row in our tables chan
 
 > In principle, it should be possible to automatically generate these hooks based on your module's schema, or use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore). For simplicity, rather than creating them mechanically, we're just going to do it manually.
 
-Let's now prettify our messages in our render function by sorting them by their `sent` timestamp, and joining the username of the sender to the message by looking up the user by their `Identity` in the `user` table. Replace `const prettyMessages: PrettyMessage[] = []` with the below.
+Next add let's add these hooks to our `App` component just below our connection setup:
 
 ```tsx
   const messages = useMessages(conn);
   const users = useUsers(conn);
+```
 
-  const prettyMessages: PrettyMessage[] = messages 
-    .sort((a, b) => a.sent > b.sent ? 1 : -1)
-    .map((message) => ({
-      senderName: users.get(message.sender)?.name || message.sender.toHexString().substring(0, 8),
+Let's now prettify our messages in our render function by sorting them by their `sent` timestamp, and joining the username of the sender to the message by looking up the user by their `Identity` in the `user` table. Replace `const prettyMessages: PrettyMessage[] = [];` with the following:
+
+```tsx
+  const prettyMessages: PrettyMessage[] = messages
+    .sort((a, b) => (a.sent > b.sent ? 1 : -1))
+    .map(message => ({
+      senderName:
+        users.get(message.sender.toHexString())?.name ||
+        message.sender.toHexString().substring(0, 8),
       text: message.text,
     }));
 ```
 
 That's all we have to do to hook up our SpacetimeDB state to our React state. SpacetimeDB will make sure that any change on the server gets pushed down to our application and rerendered on screen in real-time.
+
+Let's also update our render function to show a loading message while we're connecting to SpacetimeDB. Add this just below our `prettyMessages` declaration:
+
+```tsx
+  if (!conn || !connected || !identity) {
+    return (
+      <div className="App">
+        <h1>Connecting...</h1>
+      </div>
+    );
+  }
+```
+
+Finally, let's also compute the name of the user from the `Identity` in our `name` variable. Replace `const name = '';` with the following:
+
+```tsx
+  const name =
+    users.get(identity?.toHexString())?.name ||
+    identity?.toHexString().substring(0, 8) ||
+    'unknown';
+```
 
 ### Calling Reducers
 
@@ -404,14 +630,17 @@ Our `user` table includes all users not just online users, so we want to take ca
     if (!conn) return;
     conn.db.user.onInsert((_ctx, user) => {
       if (user.online) {
-        setSystemMessage(prev => prev.join(`${user.name} has connected.`, \n));
+        const name = user.name || user.identity.toHexString().substring(0, 8);
+        setSystemMessage(prev => prev + `\n${name} has connected.`);
       }
     });
     conn.db.user.onUpdate((_ctx, oldUser, newUser) => {
+      const name =
+        newUser.name || newUser.identity.toHexString().substring(0, 8);
       if (oldUser.online === false && newUser.online === true) {
-        setSystemMessage(`${newUser.name} has connected.`);
+        setSystemMessage(prev => prev + `\n${name} has connected.`);
       } else if (oldUser.online === true && newUser.online === false) {
-        setSystemMessage(`${oldUser.name} has disconnected.`);
+        setSystemMessage(prev => prev + `\n${name} has disconnected.`);
       }
     });
   }, [conn]);

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -395,7 +395,7 @@ import { Identity } from '@clockworklabs/spacetimedb-sdk';
 
 Now that we've imported the `DBConnection` type, we can use it to connect our app to our module.
 
-Add the following to your `App` function, just below `const [newMessage, setNewMessage] = useState("");`:
+Add the following to your `App` function, just below `const [newMessage, setNewMessage] = useState('');`:
 
 ```tsx
   const [connected, setConnected] = useState<boolean>(false);

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -1,8 +1,13 @@
-# Typescript Client SDK Quickstart
+# TypeScript Client SDK Quickstart
 
-In this guide we'll show you how to get up and running with a simple SpacetimeDB app with a client written in Typescript.
+In this guide, you'll learn how to use TypeScript to create a SpacetimeDB client application. While we currently support TypeScript as a client language, we do not yet support writing SpacetimeDB server modules in TypeScript.
 
-We'll implement a basic single page web app for the module created in our Rust or C# Module Quickstart guides. **Make sure you follow one of these guides before you start on this one.**
+**Before you get started on this guide**, you should complete one of the quickstart guides for creating a SpacetimeDB server module listed below.
+
+- [Rust](/docs/modules/rust/quickstart)
+- [C#](/docs/modules/csharp/quickstart)
+
+By the end of this introduciton, you will have created a basic single page web app for the module created in the above module quickstart guides.
 
 ## Project structure
 
@@ -15,37 +20,39 @@ cd quickstart-chat
 Within it, create a `client` react app:
 
 ```bash
-npx create-react-app client --template typescript
+pnpm create vite@latest client -- --template react-ts
+cd client
+pnpm install
 ```
 
 We also need to install the `spacetime-client-sdk` package:
 
 ```bash
-cd client
-npm install @clockworklabs/spacetimedb-sdk
+pnpm install @clockworklabs/spacetimedb-sdk@1.0.0-rc1.0
 ```
+
+> If you are using another package manager like `yarn` or `npm` the same steps should work with the appropriate commands for those tools.
+
+If you like, you can now run `pnpm run dev` to see the vite template app running at `http://localhost:5173`.
 
 ## Basic layout
 
-We are going to start by creating a basic layout for our app. The page contains four sections:
+The app we're going to create is a basic chat application. We are going to start by creating a layout for our app. The webpage page will contain four sections:
 
 1. A profile section, where we can set our name.
 2. A message section, where we can see all the messages.
 3. A system section, where we can see system messages.
 4. A new message section, where we can send a new message.
 
-The `onSubmitNewName` and `onMessageSubmit` callbacks will be called when the user clicks the submit button in the profile and new message sections, respectively. We'll hook these up later.
-
 Replace the entire contents of `client/src/App.tsx` with the following:
 
-```typescript
+```tsx
 import React, { useEffect, useState } from "react";
-import logo from "./logo.svg";
 import "./App.css";
 
-export type MessageType = {
-  name: string;
-  message: string;
+export type PrettyMessage = {
+  senderName: string;
+  text: string;
 };
 
 function App() {
@@ -53,9 +60,9 @@ function App() {
   const [settingName, setSettingName] = useState(false);
   const [name, setName] = useState("");
   const [systemMessage, setSystemMessage] = useState("");
-  const [messages, setMessages] = useState<MessageType[]>([]);
-
   const [newMessage, setNewMessage] = useState("");
+
+  const prettyMessages: PrettyMessage[] = [];
 
   const onSubmitNewName = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -63,14 +70,14 @@ function App() {
     // Fill in app logic here
   };
 
-  const onMessageSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmitMessage = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // Fill in app logic here
     setNewMessage("");
+    // Fill in app logic here
   };
 
   return (
-    <div className="App">
+    <div className="app">
       <div className="profile">
         <h1>Profile</h1>
         {!settingName ? (
@@ -99,14 +106,14 @@ function App() {
       </div>
       <div className="message">
         <h1>Messages</h1>
-        {messages.length < 1 && <p>No messages</p>}
+        {prettyMessages.length < 1 && <p>No messages</p>}
         <div>
-          {messages.map((message, key) => (
+          {prettyMessages.map((message, key) => (
             <div key={key}>
               <p>
-                <b>{message.name}</b>
+                <b>{message.senderName}</b>
               </p>
-              <p>{message.message}</p>
+              <p>{message.text}</p>
             </div>
           ))}
         </div>
@@ -119,7 +126,7 @@ function App() {
       </div>
       <div className="new-message">
         <form
-          onSubmit={onMessageSubmit}
+          onSubmit={onSubmitMessage}
           style={{
             display: "flex",
             flexDirection: "column",
@@ -142,7 +149,9 @@ function App() {
 export default App;
 ```
 
-Now when you run `npm start`, you should see a basic chat app that does not yet send or receive messages.
+We have configured the `onSubmitNewName` and `onSubmitMessage` callbacks to be called when the user clicks the submit button in the profile and new message sections, respectively. For now, they do nothing when called, but later we'll add some logic to call SpacetimeDB reducers when these callbacks are called.
+
+Now when you run `pnpm run dev` and open `http://localhost:5173`, you should see a basic chat app that does not yet send or receive messages.
 
 ## Generate your module types
 
@@ -155,352 +164,269 @@ mkdir -p client/src/module_bindings
 spacetime generate --lang typescript --out-dir client/src/module_bindings --project-path server
 ```
 
-Take a look inside `client/src/module_bindings`. The CLI should have generated four files:
+> This command assumes you've already created a server module in `quickstart-chat/server`.
+
+Take a look inside `client/src/module_bindings`. The CLI should have generated several files:
 
 ```
 module_bindings
-├── message.ts
+├── identity_connected_reducer.ts
+├── identity_disconnected_reducer.ts
+├── index.ts
+├── init_reducer.ts
+├── message_table.ts
+├── message_type.ts
 ├── send_message_reducer.ts
 ├── set_name_reducer.ts
-└── user.ts
+├── user_table.ts
+└── user_type.ts
 ```
 
-We need to import these types into our `client/src/App.tsx`. While we are at it, we will also import the SpacetimeDBClient class from our SDK. In order to let the SDK know what tables and reducers we will be using we need to also register them.
+With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. The main entry to the SpacetimeDB API is via the `DBConnection` which was generated into the `module_bindings` folder. Let's import it and a few other types into our `client/src/App.tsx`.
 
-```typescript
-import {
-  SpacetimeDBClient,
-  Identity,
-  Address,
-} from '@clockworklabs/spacetimedb-sdk';
-
-import Message from './module_bindings/message';
-import User from './module_bindings/user';
-import SendMessageReducer from './module_bindings/send_message_reducer';
-import SetNameReducer from './module_bindings/set_name_reducer';
-
-SpacetimeDBClient.registerReducers(SendMessageReducer, SetNameReducer);
-SpacetimeDBClient.registerTables(Message, User);
+```tsx
+import { DBConnection } from './module_bindings';
+import { Identity } from '@clockworklabs/spacetimedb-sdk';
 ```
 
 ## Create your SpacetimeDB client
 
-First, we need to create a SpacetimeDB client and connect to the module. Create your client at the top of the `App` function.
+Now that we've imported the `DBConnection` type we can use it to connect our app to our module.
 
-We are going to create a stateful variable to store our client's SpacetimeDB identity when we receive it. Also, we are using `localStorage` to retrieve your auth token if this client has connected before. We will explain these later.
+Add the following `App` function, just below `const [newMessage, setNewMessage] = useState("");`:
 
-Replace `<module-name>` with the name you chose when publishing your module during the module quickstart. If you are using SpacetimeDB Cloud, the host will be `wss://spacetimedb.com/spacetimedb`.
+```tsx
+  const [connected, setConnected] = useState<boolean>(false);
+  const [identity, setIdentity] = useState<Identity | null>(null);
 
-Add this before the `App` function declaration:
+  const [conn] = useState(DBConnection.builder()
+      .withUri('ws://localhost:3000')
+      .withModuleName('quickstart-chat')
+      .onConnect((conn, identity, token) => {
+        setIdentity(identity);
+        setConnected(true);
 
-```typescript
-let token = localStorage.getItem('auth_token') || undefined;
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'chat',
-  token
-);
+        console.log("Connected to SpacetimeDB with identity:", identity.toHexString());
+
+        // Subscribe to the `message` table.
+        conn.subscriptionBuilder().onApplied(() => {
+          console.log("SDK client cache initialized.");
+        }).subscribe(['SELECT * FROM message']);
+      })
+      .onConnectError((_conn, err) => {
+        console.error("Error connecting to SpacetimeDB:", err);
+      })
+      .onDisconnect(() => {
+        console.log("Disconnected from SpacetimeDB");
+        setConnected(false);
+      })
+      .build()
+  );
 ```
 
-Inside the `App` function, add a few refs:
+Here we are configuring our SpacetimeDB connection by specifying the server URI, module name, and an `onConnect` callback. When `onConnect` is called after connecting, we store the connection state, our `Identity`, and our SpacetimeDB credentials in our React state. If there is an error connecting, we print that error to the console as well.
 
-```typescript
-let local_identity = useRef<Identity | undefined>(undefined);
-let initialized = useRef<boolean>(false);
-const client = useRef<SpacetimeDBClient>(spacetimeDBClient);
+If you chose a different name for your module, replace `quickstart-chat` with that name, or republish your module as `quickstart-chat`.
+
+In this case, we are not connecting to SpacetimeDB with pre-existing credentials so SpacetimeDB is assigning us a new `Identity` and token on connection. In order to connect to SpacetimeDB as the same user after refreshing, let's store the credentials in `localStorage` and pass them in when connecting. Modify your code with the following:
+
+```tsx
+  const [connected, setConnected] = useState<boolean>(false);
+  const [identity, setIdentity] = useState<Identity | null>(null);
+
+  const [conn] = useState(DBConnection.builder()
+      .withUri('ws://localhost:3000')
+      .withModuleName('quickstart-chat')
+      .withToken(localStorage.getItem('auth_token') || undefined)
+      .onConnect((conn, identity, token) => {
+        setIdentity(identity);
+        setConnected(true);
+        localStorage.setItem('auth_token', token);
+
+        console.log("Connected to SpacetimeDB with identity:", identity.toHexString());
+
+        // Subscribe to the `message` table.
+        conn.subscriptionBuilder().onApplied(() => {
+          console.log("SDK client cache initialized.");
+        }).subscribe(['SELECT * FROM message']);
+      })
+      .onConnectError((_conn, err) => {
+        console.error("Error connecting to SpacetimeDB:", err);
+      })
+      .onDisconnect(() => {
+        console.log("Disconnected from SpacetimeDB");
+        setConnected(false);
+      })
+      .build()
+  );
 ```
 
-## Register callbacks and connect
+In the `onConnect` function we are also subscribing to the `message` table. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "SDK client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
 
-We need to handle several sorts of events:
+### Accessing the Data
 
-1. `onConnect`: When we connect and receive our credentials, we'll save them to browser local storage, so that the next time we connect, we can re-authenticate as the same user.
-2. `initialStateSync`: When we're informed of the backlog of past messages, we'll sort them and update the `message` section of the page.
-3. `Message.onInsert`: When we receive a new message, we'll update the `message` section of the page.
-4. `User.onInsert`: When a new user joins, we'll update the `system` section of the page with an appropiate message.
-5. `User.onUpdate`: When a user is updated, we'll add a message with their new name, or declare their new online status to the `system` section of the page.
-6. `SetNameReducer.on`: If the server rejects our attempt to set our name, we'll update the `system` section of the page with an appropriate error message.
-7. `SendMessageReducer.on`: If the server rejects a message we send, we'll update the `system` section of the page with an appropriate error message.
+Once SpacetimeDB is connected, we can easily access the data inside of the client cache using our connection. The `conn.db` field allows you to access all of the tables of your database. Those tables will contain all data which you have subscribed to in your subscription configuration.
 
-We will add callbacks for each of these items in the following sections. All of these callbacks will be registered inside the `App` function after the `useRef` declarations.
+Let's create custom React hooks for the `message` and `user` tables. Add the following code above your `App` component:
 
-### onConnect Callback
+```tsx
+function useMessages(conn: DBConnection): Message[] {
+  const [messages, setMessages] = useState<Message[]>([]);
 
-On connect SpacetimeDB will provide us with our client credentials.
-
-Each user has a set of credentials, which consists of two parts:
-
-- An `Identity`, a unique public identifier. We're using these to identify `User` rows.
-- A `Token`, a private key which SpacetimeDB uses to authenticate the client.
-
-These credentials are generated by SpacetimeDB each time a new client connects, and sent to the client so they can be saved, in order to re-connect with the same identity.
-
-We want to store our local client identity in a stateful variable and also save our `token` to local storage for future connections.
-
-Each client also has an `Address`, which modules can use to distinguish multiple concurrent connections by the same `Identity`. We don't need to know our `Address`, so we'll ignore that argument.
-
-Once we are connected, we can send our subscription to the SpacetimeDB module. SpacetimeDB is set up so that each client subscribes via SQL queries to some subset of the database, and is notified about changes only to that subset. For complex apps with large databases, judicious subscriptions can save each client significant network bandwidth, memory and computation compared. For example, in [BitCraft](https://bitcraftonline.com), each player's client subscribes only to the entities in the "chunk" of the world where that player currently resides, rather than the entire game world. Our app is much simpler than BitCraft, so we'll just subscribe to the whole database.
-
-To the body of `App`, add:
-
-```typescript
-client.current.onConnect((token, identity, address) => {
-  console.log('Connected to SpacetimeDB');
-
-  local_identity.current = identity;
-
-  localStorage.setItem('auth_token', token);
-
-  client.current.subscribe(['SELECT * FROM User', 'SELECT * FROM Message']);
-});
-```
-
-### initialStateSync callback
-
-This callback fires when our local client cache of the database is populated. This is a good time to set the initial messages list.
-
-We'll define a helper function, `setAllMessagesInOrder`, to supply the `MessageType` class for our React application. It will call the autogenerated `Message.all` function to get an array of `Message` rows, then sort them and convert them to `MessageType`.
-
-To find the `User` based on the message's `sender` identity, we'll use `User::findByIdentity`, which behaves like the same function on the server.
-
-Whenever we want to display a user name, if they have set a name, we'll use that. If they haven't set a name, we'll instead use the first 8 bytes of their identity, encoded as hexadecimal. We'll define the function `userNameOrIdentity` to handle this.
-
-We also have to handle the case where we don't find a matching `User` row. This can happen when the module owner sends a message using the CLI's `spacetime call`. In this case, we'll display `unknown`.
-
-To the body of `App`, add:
-
-```typescript
-function userNameOrIdentity(user: User): string {
-  console.log(`Name: ${user.name} `);
-  if (user.name !== null) {
-    return user.name || '';
-  } else {
-    var identityStr = new Identity(user.identity).toHexString();
-    console.log(`Name: ${identityStr} `);
-    return new Identity(user.identity).toHexString().substring(0, 8);
-  }
-}
-
-function setAllMessagesInOrder() {
-  let messages = Array.from(Message.all());
-  messages.sort((a, b) => (a.sent > b.sent ? 1 : a.sent < b.sent ? -1 : 0));
-
-  let messagesType: MessageType[] = messages.map(message => {
-    let sender_identity = User.findByIdentity(message.sender);
-    let display_name = sender_identity
-      ? userNameOrIdentity(sender_identity)
-      : 'unknown';
-
-    return {
-      name: display_name,
-      message: message.text,
+  useEffect(() => {
+    const onInsert = (_ctx: EventContext, message: Message) => {
+      setMessages((prev) => [...prev, message]);
     };
-  });
+    conn.db.message.onInsert(onInsert);
 
-  setMessages(messagesType);
+    const onDelete = (_ctx: EventContext, message: Message) => {
+      setMessages((prev) => prev.filter((m) => m.text !== message.text && m.sent !== message.sent && m.sender !== message.sender));
+    };
+    conn.db.message.onDelete(onDelete);
+
+    return () => {
+      conn.db.message.removeOnInsert(onInsert);
+      conn.db.message.removeOnDelete(onDelete);
+    };
+  }, [conn]);
+
+  return messages;
 }
 
-client.current.on('initialStateSync', () => {
-  setAllMessagesInOrder();
-  var user = User.findByIdentity(local_identity?.current?.toUint8Array()!);
-  setName(userNameOrIdentity(user!));
-});
+function useUsers(conn: DBConnection): Map<string, User> {
+  const [users, setUsers] = useState<Map<string, User>>(new Map());
+
+  useEffect(() => {
+    const onInsert = (_ctx: EventContext, user: User) => {
+      setUsers((prev) => new Map(prev.set(user.identity.toHexString(), user)));
+    };
+    conn.db.user.onInsert(onInsert);
+
+    const onUpdate = (_ctx: EventContext, oldUser: User, newUser: User) => {
+      setUsers((prev) => {
+        prev.delete(oldUser.identity.toHexString());
+        return new Map(prev.set(newUser.identity.toHexString(), newUser));
+      });
+    };
+    conn.db.user.onUpdate(onUpdate);
+
+    const onDelete = (_ctx: EventContext, user: User) => {
+      setUsers((prev) => {
+        prev.delete(user.identity.toHexString());
+        return new Map(prev);
+      });
+    };
+    conn.db.user.onDelete(onDelete);
+
+    return () => {
+      conn.db.user.removeOnInsert(onInsert);
+      conn.db.user.removeOnUpdate(onUpdate);
+      conn.db.user.removeOnDelete(onDelete);
+    };
+  }, [conn]);
+
+  return users;
+}
 ```
 
-### Message.onInsert callback - Update messages
+These custom React hooks update the React state anytime a row in our tables change, causing React to rerender.
 
-When we receive a new message, we'll update the messages section of the page. Keep in mind that we only want to do this for new messages, i.e. those inserted by a `send_message` reducer invocation. When the server is initializing our cache, we'll get a callback for each existing message, but we don't want to update the page for those. To that effect, our `onInsert` callback will check if its `ReducerEvent` argument is not `undefined`, and only update the `message` section in that case.
+> In principle, it should be possible to automatically generate these hooks based on your module's schema, or use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore). For simplicity, rather than creating them mechanically, we're just going to do it manually.
 
-To the body of `App`, add:
+Let's now prettify our messages in our render function by sorting them by their `sent` timestamp, and joining the username of the sender to the message by looking up the user by their `Identity` in the `user` table. Replace `const prettyMessages: PrettyMessage[] = []` with the below.
 
-```typescript
-Message.onInsert((message, reducerEvent) => {
-  if (reducerEvent !== undefined) {
-    setAllMessagesInOrder();
-  }
-});
+```tsx
+  const messages = useMessages(conn);
+  const users = useUsers(conn);
+
+  const prettyMessages: PrettyMessage[] = messages 
+    .sort((a, b) => a.sent > b.sent ? 1 : -1)
+    .map((message) => ({
+      senderName: users.get(message.sender)?.name || message.sender.toHexString().substring(0, 8),
+      text: message.text,
+    }));
 ```
 
-### User.onInsert callback - Notify about new users
+That's all we have to do to hook up our SpacetimeDB state to our React state. SpacetimeDB will make sure that any change on the server gets pushed down to our application and rerendered on screen in real-time.
 
-For each table, we can register on-insert and on-delete callbacks to be run whenever a subscribed row is inserted or deleted. We register these callbacks using the `onInsert` and `onDelete` methods of the trait `TableType`, which is automatically implemented for each table by `spacetime generate`.
+### Calling Reducers
 
-These callbacks can fire in two contexts:
+Let's hook up our callbacks so we can send some messages and see them displayed in the app after being synchronized by SpacetimeDB. We need to update the `onSubmitNewName` and `onSubmitMessage` callbacks to send the appropriate reducer to the module.
+
+Modify the `onSubmitNewName` callback by adding a call to the `setName` reducer:
+
+```tsx
+  const onSubmitNewName = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSettingName(false);
+    conn.reducers.setName(newName);
+  };
+```
+
+Next modify the `onSubmitMessage` callback by adding a call to the `sendMessage` reducer:
+
+```tsx
+  const onMessageSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setNewMessage("");
+    conn.reducers.sendMessage(newMessage);
+  };
+```
+
+SpacetimeDB generated these functions for us based on the type information provided by our module. Calling these functions will invoke our reducers in our module.
+
+Let's try out our app to see the result of these changes.
+
+```sh
+cd client
+pnpm run dev
+```
+
+> Don't forget! You may need to publish your server module if you haven't yet.
+
+Send some messages and update your username and watch it change in real-time. Note that when you update your username it also updates immediately for all prior messages. This is because the messages store the user's `Identity` directly, instead of their username, so we can retroactively apply their username to all prior messages.
+
+Try opening a few incognito windows to see what it's like with multiple users!
+
+### Notify about new users
+
+We can also register `onInsert` and `onDelete` callbacks for the purpose of handling events, not just state. For example, we might want to show a notification any time a new user connects to the module.
+
+Note that these callbacks can fire in two contexts:
 
 - After a reducer runs, when the client's cache is updated about changes to subscribed rows.
 - After calling `subscribe`, when the client's cache is initialized with all existing matching rows.
 
-This second case means that, even though the module only ever inserts online users, the client's `User.onInsert` callbacks may be invoked with users who are offline. We'll only notify about online users.
+Our `user` table includes all users not just online users, so we want to take care to only show a notification when new users join. Let's add a `useEffect` which subscribes a callback when a `user` is inserted into the table and a callback when a `user` is updated.
 
-`onInsert` and `onDelete` callbacks take two arguments: the altered row, and a `ReducerEvent | undefined`. This will be `undefined` for rows inserted when initializing the cache for a subscription. `ReducerEvent` is a class containing information about the reducer that triggered this event. For now, we can ignore this argument.
-
-We are going to add a helper function called `appendToSystemMessage` that will append a line to the `systemMessage` state. We will use this to update the `system` message when a new user joins.
-
-To the body of `App`, add:
-
-```typescript
-// Helper function to append a line to the systemMessage state
-function appendToSystemMessage(line: String) {
-  setSystemMessage(prevMessage => prevMessage + '\n' + line);
-}
-
-User.onInsert((user, reducerEvent) => {
-  if (user.online) {
-    appendToSystemMessage(`${userNameOrIdentity(user)} has connected.`);
-  }
-});
+```tsx
+  useEffect(() => {
+    if (!conn) return;
+    conn.db.user.onInsert((_ctx, user) => {
+      if (user.online) {
+        setSystemMessage(prev => prev.join(`${user.name} has connected.`, \n));
+      }
+    });
+    conn.db.user.onUpdate((_ctx, oldUser, newUser) => {
+      if (oldUser.online === false && newUser.online === true) {
+        setSystemMessage(`${newUser.name} has connected.`);
+      } else if (oldUser.online === true && newUser.online === false) {
+        setSystemMessage(`${oldUser.name} has disconnected.`);
+      }
+    });
+  }, [conn]);
 ```
 
-### User.onUpdate callback - Notify about updated users
+Here we post a message saying a new user has connected if the user is being added to the `user` table and they're online, or if an existing user's online status is being set to "online".
 
-Because we declared a `#[primarykey]` column in our `User` table, we can also register on-update callbacks. These run whenever a row is replaced by a row with the same primary key, like our module's `User::update_by_identity` calls. We register these callbacks using the `onUpdate` method which is automatically implemented by `spacetime generate` for any table with a `#[primarykey]` column.
+Note that `onInsert` and `onDelete` callbacks takes two arguments: an `EventContext` and the row. The `EventContext` can be used just like the `DBConnection` and has all the same access functions, in addition to containing information about the event that triggered this callback. For now, we can ignore this argument though, since we have all the info we need in the user rows.
 
-`onUpdate` callbacks take three arguments: the old row, the new row, and a `ReducerEvent`.
-
-In our module, users can be updated for three reasons:
-
-1. They've set their name using the `set_name` reducer.
-2. They're an existing user re-connecting, so their `online` has been set to `true`.
-3. They've disconnected, so their `online` has been set to `false`.
-
-We'll update the `system` message in each of these cases.
-
-To the body of `App`, add:
-
-```typescript
-User.onUpdate((oldUser, user, reducerEvent) => {
-  if (oldUser.online === false && user.online === true) {
-    appendToSystemMessage(`${userNameOrIdentity(user)} has connected.`);
-  } else if (oldUser.online === true && user.online === false) {
-    appendToSystemMessage(`${userNameOrIdentity(user)} has disconnected.`);
-  }
-
-  if (user.name !== oldUser.name) {
-    appendToSystemMessage(
-      `User ${userNameOrIdentity(oldUser)} renamed to ${userNameOrIdentity(
-        user
-      )}.`
-    );
-  }
-});
-```
-
-### SetNameReducer.on callback - Handle errors and update profile name
-
-We can also register callbacks to run each time a reducer is invoked. We register these callbacks using the `OnReducer` method which is automatically implemented for each reducer by `spacetime generate`.
-
-Each reducer callback takes a number of parameters:
-
-1. `ReducerEvent` that contains information about the reducer that triggered this event. It contains several fields. The ones we care about are:
-
-   - `callerIdentity`: The `Identity` of the client that called the reducer.
-   - `status`: The `Status` of the reducer run, one of `"Committed"`, `"Failed"` or `"OutOfEnergy"`.
-   - `message`: The error message, if any, that the reducer returned.
-
-2. The rest of the parameters are arguments passed to the reducer.
-
-These callbacks will be invoked in one of two cases:
-
-1. If the reducer was successful and altered any of our subscribed rows.
-2. If we requested an invocation which failed.
-
-Note that a status of `Failed` or `OutOfEnergy` implies that the caller identity is our own identity.
-
-We already handle other users' `set_name` calls using our `User.onUpdate` callback, but we need some additional behavior for setting our own name. If our name was rejected, we'll update the `system` message. If our name was accepted, we'll update our name in the app.
-
-We'll test both that our identity matches the sender and that the status is `Failed`, even though the latter implies the former, for demonstration purposes.
-
-If the reducer status comes back as `committed`, we'll update the name in our app.
-
-To the body of `App`, add:
-
-```typescript
-SetNameReducer.on((reducerEvent, newName) => {
-  if (
-    local_identity.current &&
-    reducerEvent.callerIdentity.isEqual(local_identity.current)
-  ) {
-    if (reducerEvent.status === 'failed') {
-      appendToSystemMessage(`Error setting name: ${reducerEvent.message} `);
-    } else if (reducerEvent.status === 'committed') {
-      setName(newName);
-    }
-  }
-});
-```
-
-### SendMessageReducer.on callback - Handle errors
-
-We handle warnings on rejected messages the same way as rejected names, though the types and the error message are different. We don't need to do anything for successful SendMessage reducer runs; our Message.onInsert callback already displays them.
-
-To the body of `App`, add:
-
-```typescript
-SendMessageReducer.on((reducerEvent, newMessage) => {
-  if (
-    local_identity.current &&
-    reducerEvent.callerIdentity.isEqual(local_identity.current)
-  ) {
-    if (reducerEvent.status === 'failed') {
-      appendToSystemMessage(`Error sending message: ${reducerEvent.message} `);
-    }
-  }
-});
-```
-
-## Update the UI button callbacks
-
-We need to update the `onSubmitNewName` and `onMessageSubmit` callbacks to send the appropriate reducer to the module.
-
-`spacetime generate` defined two functions for us, `SetNameReducer.call` and `SendMessageReducer.call`, which send a message to the database to invoke the corresponding reducer. The first argument, the `ReducerContext`, is supplied by the server, but we pass all other arguments ourselves. In our case, that means that both `SetNameReducer.call` and `SendMessageReducer.call` take one argument, a `String`.
-
-Add the following to the `onSubmitNewName` callback:
-
-```typescript
-SetNameReducer.call(newName);
-```
-
-Add the following to the `onMessageSubmit` callback:
-
-```typescript
-SendMessageReducer.call(newMessage);
-```
-
-## Connecting to the module
-
-We need to connect to the module when the app loads. We'll do this by adding a `useEffect` hook to the `App` function. This hook should only run once, when the component is mounted, but we are going to use an `initialized` boolean to ensure that it only runs once.
-
-```typescript
-useEffect(() => {
-  if (!initialized.current) {
-    client.current.connect();
-    initialized.current = true;
-  }
-}, []);
-```
-
-## What's next?
-
-When you run `npm start` you should see a chat app that can send and receive messages. If you open it in multiple private browser windows, you should see that messages are synchronized between them.
+## Conclusion
 
 Congratulations! You've built a simple chat app with SpacetimeDB. You can find the full source code for this app [here](https://github.com/clockworklabs/spacetimedb-typescript-sdk/tree/main/examples/quickstart)
 
-For a more advanced example of the SpacetimeDB TypeScript SDK, take a look at the [Spacetime MUD (multi-user dungeon)](https://github.com/clockworklabs/spacetime-mud/tree/main/react-client).
+At this point you've learned how to create a basic TypeScript client for your SpacetimeDB `quickstart-chat` module. You've learned how to connect to SpacetimeDB and call reducers to update data. You've learned how to subscribe to table data, and hook it up so that it updates reactively in a React application.
 
-## Troubleshooting
+## What's next?
 
-If you encounter the following error:
-
-```
-TS2802: Type 'IterableIterator<any>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
-```
-
-You can fix it by changing your compiler target. Add the following to your `tsconfig.json` file:
-
-```json
-{
-  "compilerOptions": {
-    "target": "es2015"
-  }
-}
-```
+We covered a lot here, but we haven't covered everything. Take a look at our [reference documentation](/docs/sdks/typescript) to find out how you can use SpacetimeDB in more advanced ways, including managing reducer errors and subscribing to reducer events.

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -455,7 +455,7 @@ In the `onConnect` function we are also subscribing to the `message` and `user` 
 
 ### Accessing the Data
 
-Once SpacetimeDB is connected, we can easily access the data inside of the client cache using our connection. The `conn.db` field allows you to access all of the tables of your database. Those tables will contain all data which you have subscribed to in your subscription configuration.
+Once SpacetimeDB is connected, we can easily access the data in the client cache using our `DBConnection`. The `conn.db` field allows you to access all of the tables of your database. Those tables will contain all data requested by your subscription configuration.
 
 Let's create custom React hooks for the `message` and `user` tables. Add the following code above your `App` component:
 
@@ -623,7 +623,7 @@ Note that these callbacks can fire in two contexts:
 - After a reducer runs, when the client's cache is updated about changes to subscribed rows.
 - After calling `subscribe`, when the client's cache is initialized with all existing matching rows.
 
-Our `user` table includes all users not just online users, so we want to take care to only show a notification when new users join. Let's add a `useEffect` which subscribes a callback when a `user` is inserted into the table and a callback when a `user` is updated.
+Our `user` table includes all users not just online users, so we want to take care to only show a notification when new users join. Let's add a `useEffect` which subscribes a callback when a `user` is inserted into the table and a callback when a `user` is updated. Add the following to your `App` component just below the other `useEffect`.
 
 ```tsx
   useEffect(() => {

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -7,7 +7,7 @@ In this guide, you'll learn how to use TypeScript to create a SpacetimeDB client
 - [Rust](/docs/modules/rust/quickstart)
 - [C#](/docs/modules/c-sharp/quickstart)
 
-By the end of this introduciton, you will have created a basic single page web app for the module created in the above module quickstart guides.
+By the end of this introduciton, you will have created a basic single page web app which connects to the `quickstart-chat` module created in the above module quickstart guides.
 
 ## Project structure
 

--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -384,7 +384,7 @@ module_bindings
 └── user_type.ts
 ```
 
-With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. The main entry to the SpacetimeDB API is via the `DBConnection` which was generated into the `module_bindings` folder. Let's import it and a few other types into our `client/src/App.tsx`.
+With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. We've placed these in the `module_bindings` folder. The main entry to the SpacetimeDB API is the `DBConnection`, a type which manages a connection to a remote database. Let's import it and a few other types into our `client/src/App.tsx`.
 
 ```tsx
 import { DBConnection, EventContext, Message, User } from './module_bindings';


### PR DESCRIPTION
This PR updates the quickstart guide to be compatible with the 1.0 API. It also cleans up some of the CSS and now uses React best practices (as far as I know them), including custom hooks. It's self contained an all the links work.

This is the companion PR to: https://github.com/clockworklabs/spacetimedb-typescript-sdk/pull/130

NOTE: It does use the old subscription API. I propose that we test and merge this and then update that API in a separate PR. This API will work with the existing SpacetimeDB.

Note to @rekhoff, could you please run through this guide once to make sure it's working on your end.

