### PR TITLE
Rekhoff/unity blackhol.io tutorial switcher (#140)

### DIFF
--- a/docs/unity/index.md
+++ b/docs/unity/index.md
@@ -2,26 +2,26 @@
 
 Need help with the tutorial or CLI commands? [Join our Discord server](https://discord.gg/spacetimedb)!
 
-In this tutorial you'll learn how to build a small-scoped MMORPG in Unity, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquanted with all the features and best practices of SpacetimeDB, while building a fun little game.
+In this tutorial you'll learn how to build a small-scoped MMORPG in Unity, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquanted with all the features and best practices of SpacetimeDB, while building [a fun little game](https://github.com/ClockworkLabs/Blackholio).
 
 By the end, you should have a basic understanding of what SpacetimeDB offers for developers making multiplayer games. 
 
 The game is inspired by [agar.io](https://agar.io), but SpacetimeDB themed with some fun twists. If you're not familiar [agar.io](https://agar.io), it's a web game in which you and hundreds of other players compete to cultivate mass to become the largest cell in the Petri dish.
 
-Our game, called Blackhol.io, will be similar but with space themes in twists. It should give you a great idea of the types of games you can develop with SpacetimeDB.
+Our game, called [Blackhol.io](https://github.com/ClockworkLabs/Blackholio), will be similar but space themed. It should give you a great idea of the types of games you can develop easily with SpacetimeDB.
 
-This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and coding. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
+This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and programming. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
 
-The SpacetimeDB Unity SDK minimum supported Unity version is `2021.2` as the SDK requires C# 9. This tutorial has been tested with the following Unity versions.
+We recommend using Unity `2022.3.32f1` or later, but the SDK's minimum supported Unity version is `2021.2` as the SDK requires C# 9. This tutorial has been tested with the following Unity versions.
 
 - `2022.3.32f1 LTS`
 - `6000.0.33f1`
 
-Please file an issue [here]() if you encounter an issue with a specific Unity version.
+Please file an issue [here](https://github.com/clockworklabs/spacetime-docs/issues) if you encounter an issue with a specific Unity version.
 
 ## Blackhol.io Tutorial - Basic Multiplayer
 
-Get started with the core client-server setup. For part 2, you may choose your server module preference of [Rust](/docs/modules/rust) or [C#](/docs/modules/c-sharp):
+First you'll get started with the core client/server setup. For part 2, you'll be able to choose between [Rust](/docs/modules/rust) or [C#](/docs/modules/c-sharp) for your server module language:
 
 - [Part 1 - Setup](/docs/unity/part-1)
 - [Part 2 - Connecting to SpacetimeDB](/docs/unity/part-2)

--- a/docs/unity/part-1.md
+++ b/docs/unity/part-1.md
@@ -38,7 +38,7 @@ Open Unity and create a new project by selecting "New" from the Unity Hub or goi
 
 **⚠️ Important: Choose the `Universal 2D`** template to select a template which uses the Unity Universal Render Pipeline.
 
-For `Project Name` use `client`. For Project Location make sure that you use your `blackholio` directory. This is the directory that we created in a previous step.
+For `Project Name` use `client-unity`. For Project Location make sure that you use your `blackholio` directory. This is the directory that we created in a previous step.
 
 <!-- ![Universal 2D Template](./part-1-universal-2d-template.png) -->
 


### PR DESCRIPTION
* Unified Rust and C# documentation for Blackhol.io

Creates a single markdown file for each page, containing both Rust and C# server implementations, using the following format: :::rust
# A rust section
:::
:::csharp
# A csharp section
:::
The visibility of each section should then be controlled by a dropdown on the website itself, leveraging tooling not contained in this branch.

* Updated language code blocks to clarify the block refers to the server's language

Prepped the combined documents to specifically tag for the server side code such that: :::server-rust
A rust server implementation section.
:::
:::server-csharp
A csharp server implementation section.
:::
And in a future additionally update the documentation to differentiate the client portion too, like: :::client-unity
A Unity client implementation section.
:::

* Update part-4.md

Added additional clarification that the linked repo contained content beyond the scope of the tutorial.

* Updated subscriptions to match new API format

* Small fixes to unity tutorial index page

* Added a note about column names to the C# tutorial

* Merged a section which was now abutting another section

* Clarified where you are supposed to put C# reducers

* Small, mostly whitespace fixes

---------