### PR TITLE
CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ git push -u origin a-branch-name-that-describes-my-change
 
 > NOTE! If you make a change to `nav.ts` you will have to run `npm run build` to generate a new `docs/nav.js` file.
 
+#### CLI Reference Section
+1. Make sure that https://github.com/clockworklabs/SpacetimeDB/pull/2276 is included in your `spacetimedb-cli` binary
+1. Run `cargo run --features markdown-docs -p spacetimedb-cli > cli-reference.md`
+
+We currently don't properly render markdown backticks and bolding that are inside of headers, so do these two manual replacements to make them look okay (these have only been tested on Linux):
+```bash
+sed -i'' -E 's!^(##) `(.*)`$!\1 \2!' docs/cli-reference.md
+sed -i'' -E 's!^(######) \*\*(.*)\*\*$!\1 <b>\2</b>!' docs/cli-reference.md
+```
+
 ### Checking Links
 
 We have a CI job which validates internal links. You can run it locally with `npm run check-links`. This will print any internal links (i.e. links to other docs pages) whose targets do not exist, including fragment links (i.e. `#`-ey links to anchors).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ This document contains the help content for the `spacetime` command-line program
 * [`spacetime start`↴](#spacetime-start)
 * [`spacetime version`↴](#spacetime-version)
 
-## <code>spacetime</code>
+## spacetime
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
@@ -82,7 +82,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime publish</code>
+## spacetime publish
 
 Create and update a SpacetimeDB database
 
@@ -110,7 +110,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <code>spacetime delete</code>
+## spacetime delete
 
 Deletes a SpacetimeDB database
 
@@ -130,7 +130,7 @@ Run `spacetime help delete` for more detailed information.
 
 
 
-## <code>spacetime logs</code>
+## spacetime logs
 
 Prints logs from a SpacetimeDB database
 
@@ -158,7 +158,7 @@ Run `spacetime help logs` for more detailed information.
 
 
 
-## <code>spacetime call</code>
+## spacetime call
 
 Invokes a reducer function in a database.
 
@@ -183,7 +183,7 @@ Run `spacetime help call` for more detailed information.
 
 
 
-## <code>spacetime describe</code>
+## spacetime describe
 
 Describe the structure of a database or entities within it.
 
@@ -212,7 +212,7 @@ Run `spacetime help describe` for more detailed information.
 
 
 
-## <code>spacetime energy</code>
+## spacetime energy
 
 Invokes commands related to database budgets.
 
@@ -227,7 +227,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime energy balance</code>
+## spacetime energy balance
 
 Show current energy balance for an identity
 
@@ -241,7 +241,7 @@ Show current energy balance for an identity
 
 
 
-## <code>spacetime sql</code>
+## spacetime sql
 
 Runs a SQL query on the database.
 
@@ -263,7 +263,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime rename</code>
+## spacetime rename
 
 Rename a database
 
@@ -284,7 +284,7 @@ Run `spacetime rename --help` for more detailed information.
 
 
 
-## <code>spacetime generate</code>
+## spacetime generate
 
 Generate client files for a spacetime module.
 
@@ -313,7 +313,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <code>spacetime list</code>
+## spacetime list
 
 Lists the databases attached to an identity.
 
@@ -328,7 +328,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime login</code>
+## spacetime login
 
 Manage your login to the SpacetimeDB CLI
 
@@ -349,7 +349,7 @@ Manage your login to the SpacetimeDB CLI
 
 
 
-## <code>spacetime login show</code>
+## spacetime login show
 
 Show the current login info
 
@@ -361,7 +361,7 @@ Show the current login info
 
 
 
-## <code>spacetime logout</code>
+## spacetime logout
 
 **Usage:** `spacetime logout [OPTIONS]`
 
@@ -373,7 +373,7 @@ Show the current login info
 
 
 
-## <code>spacetime init</code>
+## spacetime init
 
 Initializes a new spacetime project.
 
@@ -396,7 +396,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime build</code>
+## spacetime build
 
 Builds a spacetime module.
 
@@ -414,7 +414,7 @@ Builds a spacetime module.
 
 
 
-## <code>spacetime server</code>
+## spacetime server
 
 Manage the connection to the SpacetimeDB server.
 
@@ -436,7 +436,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime server list</code>
+## spacetime server list
 
 List stored server configurations
 
@@ -444,7 +444,7 @@ List stored server configurations
 
 
 
-## <code>spacetime server set-default</code>
+## spacetime server set-default
 
 Set the default server for future operations
 
@@ -456,7 +456,7 @@ Set the default server for future operations
 
 
 
-## <code>spacetime server add</code>
+## spacetime server add
 
 Add a new server configuration
 
@@ -474,7 +474,7 @@ Add a new server configuration
 
 
 
-## <code>spacetime server remove</code>
+## spacetime server remove
 
 Remove a saved server configuration
 
@@ -490,7 +490,7 @@ Remove a saved server configuration
 
 
 
-## <code>spacetime server fingerprint</code>
+## spacetime server fingerprint
 
 Show or update a saved server's fingerprint
 
@@ -506,7 +506,7 @@ Show or update a saved server's fingerprint
 
 
 
-## <code>spacetime server ping</code>
+## spacetime server ping
 
 Checks to see if a SpacetimeDB host is online
 
@@ -518,7 +518,7 @@ Checks to see if a SpacetimeDB host is online
 
 
 
-## <code>spacetime server edit</code>
+## spacetime server edit
 
 Update a saved server's nickname, host name or protocol
 
@@ -537,7 +537,7 @@ Update a saved server's nickname, host name or protocol
 
 
 
-## <code>spacetime server clear</code>
+## spacetime server clear
 
 Deletes all data from all local databases
 
@@ -550,7 +550,7 @@ Deletes all data from all local databases
 
 
 
-## <code>spacetime subscribe</code>
+## spacetime subscribe
 
 Subscribe to SQL queries on the database.
 
@@ -575,7 +575,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <code>spacetime start</code>
+## spacetime start
 
 Start a local SpacetimeDB instance
 
@@ -598,7 +598,7 @@ Run `spacetime start --help` to see all options.
 
 
 
-## <code>spacetime version</code>
+## spacetime version
 
 Manage installed spacetime versions
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ This document contains the help content for the `spacetime` command-line program
 * [`spacetime start`↴](#spacetime-start)
 * [`spacetime version`↴](#spacetime-version)
 
-## <pre><code>spacetime</code><pre>
+## <pre><code>spacetime</code></pre>
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
@@ -82,7 +82,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime publish</code><pre>
+## <pre><code>spacetime publish</code></pre>
 
 Create and update a SpacetimeDB database
 
@@ -110,7 +110,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <pre><code>spacetime delete</code><pre>
+## <pre><code>spacetime delete</code></pre>
 
 Deletes a SpacetimeDB database
 
@@ -130,7 +130,7 @@ Run `spacetime help delete` for more detailed information.
 
 
 
-## <pre><code>spacetime logs</code><pre>
+## <pre><code>spacetime logs</code></pre>
 
 Prints logs from a SpacetimeDB database
 
@@ -158,7 +158,7 @@ Run `spacetime help logs` for more detailed information.
 
 
 
-## <pre><code>spacetime call</code><pre>
+## <pre><code>spacetime call</code></pre>
 
 Invokes a reducer function in a database.
 
@@ -183,7 +183,7 @@ Run `spacetime help call` for more detailed information.
 
 
 
-## <pre><code>spacetime describe</code><pre>
+## <pre><code>spacetime describe</code></pre>
 
 Describe the structure of a database or entities within it.
 
@@ -212,7 +212,7 @@ Run `spacetime help describe` for more detailed information.
 
 
 
-## <pre><code>spacetime energy</code><pre>
+## <pre><code>spacetime energy</code></pre>
 
 Invokes commands related to database budgets.
 
@@ -227,7 +227,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime energy balance</code><pre>
+## <pre><code>spacetime energy balance</code></pre>
 
 Show current energy balance for an identity
 
@@ -241,7 +241,7 @@ Show current energy balance for an identity
 
 
 
-## <pre><code>spacetime sql</code><pre>
+## <pre><code>spacetime sql</code></pre>
 
 Runs a SQL query on the database.
 
@@ -263,7 +263,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime rename</code><pre>
+## <pre><code>spacetime rename</code></pre>
 
 Rename a database
 
@@ -284,7 +284,7 @@ Run `spacetime rename --help` for more detailed information.
 
 
 
-## <pre><code>spacetime generate</code><pre>
+## <pre><code>spacetime generate</code></pre>
 
 Generate client files for a spacetime module.
 
@@ -313,7 +313,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <pre><code>spacetime list</code><pre>
+## <pre><code>spacetime list</code></pre>
 
 Lists the databases attached to an identity.
 
@@ -328,7 +328,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime login</code><pre>
+## <pre><code>spacetime login</code></pre>
 
 Manage your login to the SpacetimeDB CLI
 
@@ -349,7 +349,7 @@ Manage your login to the SpacetimeDB CLI
 
 
 
-## <pre><code>spacetime login show</code><pre>
+## <pre><code>spacetime login show</code></pre>
 
 Show the current login info
 
@@ -361,7 +361,7 @@ Show the current login info
 
 
 
-## <pre><code>spacetime logout</code><pre>
+## <pre><code>spacetime logout</code></pre>
 
 **Usage:** `spacetime logout [OPTIONS]`
 
@@ -373,7 +373,7 @@ Show the current login info
 
 
 
-## <pre><code>spacetime init</code><pre>
+## <pre><code>spacetime init</code></pre>
 
 Initializes a new spacetime project.
 
@@ -396,7 +396,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime build</code><pre>
+## <pre><code>spacetime build</code></pre>
 
 Builds a spacetime module.
 
@@ -414,7 +414,7 @@ Builds a spacetime module.
 
 
 
-## <pre><code>spacetime server</code><pre>
+## <pre><code>spacetime server</code></pre>
 
 Manage the connection to the SpacetimeDB server.
 
@@ -436,7 +436,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime server list</code><pre>
+## <pre><code>spacetime server list</code></pre>
 
 List stored server configurations
 
@@ -444,7 +444,7 @@ List stored server configurations
 
 
 
-## <pre><code>spacetime server set-default</code><pre>
+## <pre><code>spacetime server set-default</code></pre>
 
 Set the default server for future operations
 
@@ -456,7 +456,7 @@ Set the default server for future operations
 
 
 
-## <pre><code>spacetime server add</code><pre>
+## <pre><code>spacetime server add</code></pre>
 
 Add a new server configuration
 
@@ -474,7 +474,7 @@ Add a new server configuration
 
 
 
-## <pre><code>spacetime server remove</code><pre>
+## <pre><code>spacetime server remove</code></pre>
 
 Remove a saved server configuration
 
@@ -490,7 +490,7 @@ Remove a saved server configuration
 
 
 
-## <pre><code>spacetime server fingerprint</code><pre>
+## <pre><code>spacetime server fingerprint</code></pre>
 
 Show or update a saved server's fingerprint
 
@@ -506,7 +506,7 @@ Show or update a saved server's fingerprint
 
 
 
-## <pre><code>spacetime server ping</code><pre>
+## <pre><code>spacetime server ping</code></pre>
 
 Checks to see if a SpacetimeDB host is online
 
@@ -518,7 +518,7 @@ Checks to see if a SpacetimeDB host is online
 
 
 
-## <pre><code>spacetime server edit</code><pre>
+## <pre><code>spacetime server edit</code></pre>
 
 Update a saved server's nickname, host name or protocol
 
@@ -537,7 +537,7 @@ Update a saved server's nickname, host name or protocol
 
 
 
-## <pre><code>spacetime server clear</code><pre>
+## <pre><code>spacetime server clear</code></pre>
 
 Deletes all data from all local databases
 
@@ -550,7 +550,7 @@ Deletes all data from all local databases
 
 
 
-## <pre><code>spacetime subscribe</code><pre>
+## <pre><code>spacetime subscribe</code></pre>
 
 Subscribe to SQL queries on the database.
 
@@ -575,7 +575,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime start</code><pre>
+## <pre><code>spacetime start</code></pre>
 
 Start a local SpacetimeDB instance
 
@@ -598,7 +598,7 @@ Run `spacetime start --help` to see all options.
 
 
 
-## <pre><code>spacetime version</code><pre>
+## <pre><code>spacetime version</code></pre>
 
 Manage installed spacetime versions
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,620 @@
+# Command-Line Help for `spacetime`
+
+This document contains the help content for the `spacetime` command-line program.
+
+**Command Overview:**
+
+* [`spacetime`↴](#spacetime)
+* [`spacetime publish`↴](#spacetime-publish)
+* [`spacetime delete`↴](#spacetime-delete)
+* [`spacetime logs`↴](#spacetime-logs)
+* [`spacetime call`↴](#spacetime-call)
+* [`spacetime describe`↴](#spacetime-describe)
+* [`spacetime energy`↴](#spacetime-energy)
+* [`spacetime energy balance`↴](#spacetime-energy-balance)
+* [`spacetime sql`↴](#spacetime-sql)
+* [`spacetime rename`↴](#spacetime-rename)
+* [`spacetime generate`↴](#spacetime-generate)
+* [`spacetime list`↴](#spacetime-list)
+* [`spacetime login`↴](#spacetime-login)
+* [`spacetime login show`↴](#spacetime-login-show)
+* [`spacetime logout`↴](#spacetime-logout)
+* [`spacetime init`↴](#spacetime-init)
+* [`spacetime build`↴](#spacetime-build)
+* [`spacetime server`↴](#spacetime-server)
+* [`spacetime server list`↴](#spacetime-server-list)
+* [`spacetime server set-default`↴](#spacetime-server-set-default)
+* [`spacetime server add`↴](#spacetime-server-add)
+* [`spacetime server remove`↴](#spacetime-server-remove)
+* [`spacetime server fingerprint`↴](#spacetime-server-fingerprint)
+* [`spacetime server ping`↴](#spacetime-server-ping)
+* [`spacetime server edit`↴](#spacetime-server-edit)
+* [`spacetime server clear`↴](#spacetime-server-clear)
+* [`spacetime subscribe`↴](#spacetime-subscribe)
+* [`spacetime start`↴](#spacetime-start)
+* [`spacetime version`↴](#spacetime-version)
+
+## `spacetime`
+
+**Usage:** `spacetime [OPTIONS] <COMMAND>`
+
+###### **Subcommands:**
+
+* `publish` — Create and update a SpacetimeDB database
+* `delete` — Deletes a SpacetimeDB database
+* `logs` — Prints logs from a SpacetimeDB database
+* `call` — Invokes a reducer function in a database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `describe` — Describe the structure of a database or entities within it.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `energy` — Invokes commands related to database budgets.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `sql` — Runs a SQL query on the database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `rename` — Rename a database
+* `generate` — Generate client files for a spacetime module.
+* `list` — Lists the databases attached to an identity.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `login` — Manage your login to the SpacetimeDB CLI
+* `logout` — 
+* `init` — Initializes a new spacetime project.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `build` — Builds a spacetime module.
+* `server` — Manage the connection to the SpacetimeDB server.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `subscribe` — Subscribe to SQL queries on the database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+* `start` — Start a local SpacetimeDB instance
+* `version` — Manage installed spacetime versions
+
+###### **Options:**
+
+* `--root-dir <ROOT_DIR>` — The root directory to store all spacetime files in.
+* `--config-path <CONFIG_PATH>` — The path to the cli.toml config file
+
+
+
+## `spacetime publish`
+
+Create and update a SpacetimeDB database
+
+**Usage:** `spacetime publish [OPTIONS] [name|identity]`
+
+Run `spacetime help publish` for more detailed information.
+
+###### **Arguments:**
+
+* `<NAME|IDENTITY>` — A valid domain or identity for this database
+
+###### **Options:**
+
+* `-c`, `--delete-data` — When publishing to an existing database identity, first DESTROY all data associated with the module
+* `--build-options <BUILD_OPTIONS>` — Options to pass to the build command, for example --build-options='--skip-println-checks'
+
+  Default value: ``
+* `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the module project
+
+  Default value: `.`
+* `-b`, `--bin-path <WASM_FILE>` — The system path (absolute or relative) to the compiled wasm binary we should publish, instead of building the project.
+* `--anonymous` — Perform this action with an anonymous identity
+* `-s`, `--server <SERVER>` — The nickname, domain name or URL of the server to host the database.
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime delete`
+
+Deletes a SpacetimeDB database
+
+**Usage:** `spacetime delete [OPTIONS] <database>`
+
+Run `spacetime help delete` for more detailed information.
+
+
+###### **Arguments:**
+
+* `<DATABASE>` — The name or identity of the database to delete
+
+###### **Options:**
+
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime logs`
+
+Prints logs from a SpacetimeDB database
+
+**Usage:** `spacetime logs [OPTIONS] <database>`
+
+Run `spacetime help logs` for more detailed information.
+
+
+###### **Arguments:**
+
+* `<DATABASE>` — The name or identity of the database to print logs from
+
+###### **Options:**
+
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+* `-n`, `--num-lines <NUM_LINES>` — The number of lines to print from the start of the log of this database. If no num lines is provided, all lines will be returned.
+* `-f`, `--follow` — A flag that causes logs to not stop when end of the log file is reached, but rather to wait for additional data to be appended to the input.
+* `--format <FORMAT>` — Output format for the logs
+
+  Default value: `text`
+
+  Possible values: `text`, `json`
+
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime call`
+
+Invokes a reducer function in a database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime call [OPTIONS] <database> <reducer_name> [arguments]...`
+
+Run `spacetime help call` for more detailed information.
+
+
+###### **Arguments:**
+
+* `<DATABASE>` — The database name or identity to use to invoke the call
+* `<REDUCER_NAME>` — The name of the reducer to call
+* `<ARGUMENTS>` — arguments formatted as JSON
+
+###### **Options:**
+
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+* `--anonymous` — Perform this action with an anonymous identity
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime describe`
+
+Describe the structure of a database or entities within it.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime describe [OPTIONS] --json <database> [entity_type] [entity_name]`
+
+Run `spacetime help describe` for more detailed information.
+
+
+###### **Arguments:**
+
+* `<DATABASE>` — The name or identity of the database to describe
+* `<ENTITY_TYPE>` — Whether to describe a reducer or table
+
+  Possible values: `reducer`, `table`
+
+* `<ENTITY_NAME>` — The name of the entity to describe
+
+###### **Options:**
+
+* `--json` — Output the schema in JSON format. Currently required; in the future, omitting this will give human-readable output.
+* `--anonymous` — Perform this action with an anonymous identity
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime energy`
+
+Invokes commands related to database budgets.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime energy
+       energy <COMMAND>`
+
+###### **Subcommands:**
+
+* `balance` — Show current energy balance for an identity
+
+
+
+## `spacetime energy balance`
+
+Show current energy balance for an identity
+
+**Usage:** `spacetime energy balance [OPTIONS]`
+
+###### **Options:**
+
+* `-i`, `--identity <IDENTITY>` — The identity to check the balance for. If no identity is provided, the default one will be used.
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to request balance information
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime sql`
+
+Runs a SQL query on the database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime sql [OPTIONS] <database> <query>`
+
+###### **Arguments:**
+
+* `<DATABASE>` — The name or identity of the database you would like to query
+* `<QUERY>` — The SQL query to execute
+
+###### **Options:**
+
+* `--interactive` — Instead of using a query, run an interactive command prompt for `SQL` expressions
+* `--anonymous` — Perform this action with an anonymous identity
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime rename`
+
+Rename a database
+
+**Usage:** `spacetime rename [OPTIONS] --to <new-name> <database-identity>`
+
+Run `spacetime rename --help` for more detailed information.
+
+
+###### **Arguments:**
+
+* `<DATABASE-IDENTITY>` — The database identity to rename
+
+###### **Options:**
+
+* `--to <NEW-NAME>` — The new name you would like to assign
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server on which to set the name
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime generate`
+
+Generate client files for a spacetime module.
+
+**Usage:** `spacetime spacetime generate --lang <LANG> --out-dir <DIR> [--project-path <DIR> | --bin-path <PATH>]`
+
+Run `spacetime help publish` for more detailed information.
+
+###### **Options:**
+
+* `-b`, `--bin-path <WASM_FILE>` — The system path (absolute or relative) to the compiled wasm binary we should inspect
+* `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to inspect
+
+  Default value: `.`
+* `-o`, `--out-dir <OUT_DIR>` — The system path (absolute or relative) to the generate output directory
+* `--namespace <NAMESPACE>` — The namespace that should be used
+
+  Default value: `SpacetimeDB.Types`
+* `-l`, `--lang <LANG>` — The language to generate
+
+  Possible values: `csharp`, `typescript`, `rust`
+
+* `--build-options <BUILD_OPTIONS>` — Options to pass to the build command, for example --build-options='--skip-println-checks'
+
+  Default value: ``
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime list`
+
+Lists the databases attached to an identity.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime list [OPTIONS]`
+
+###### **Options:**
+
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to list databases
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime login`
+
+Manage your login to the SpacetimeDB CLI
+
+**Usage:** `spacetime login [OPTIONS]
+       login <COMMAND>`
+
+###### **Subcommands:**
+
+* `show` — Show the current login info
+
+###### **Options:**
+
+* `--auth-host <AUTH-HOST>` — Fetch login token from a different host
+
+  Default value: `https://spacetimedb.com`
+* `--server-issued-login <SERVER>` — Log in to a SpacetimeDB server directly, without going through a global auth server
+* `--token <SPACETIMEDB-TOKEN>` — Bypass the login flow and use a login token directly
+
+
+
+## `spacetime login show`
+
+Show the current login info
+
+**Usage:** `spacetime login show [OPTIONS]`
+
+###### **Options:**
+
+* `--token` — Also show the auth token
+
+
+
+## `spacetime logout`
+
+**Usage:** `spacetime logout [OPTIONS]`
+
+###### **Options:**
+
+* `--auth-host <AUTH-HOST>` — Log out from a custom auth server
+
+  Default value: `https://spacetimedb.com`
+
+
+
+## `spacetime init`
+
+Initializes a new spacetime project.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime init --lang <lang> [project-path]`
+
+###### **Arguments:**
+
+* `<PROJECT-PATH>` — The path where we will create the spacetime project
+
+  Default value: `.`
+
+###### **Options:**
+
+* `-l`, `--lang <LANG>` — The spacetime module language.
+
+  Possible values: `csharp`, `rust`
+
+
+
+
+## `spacetime build`
+
+Builds a spacetime module.
+
+**Usage:** `spacetime build [OPTIONS]`
+
+###### **Options:**
+
+* `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to build
+
+  Default value: `.`
+* `--lint-dir <LINT_DIR>` — The directory to lint for nonfunctional print statements. If set to the empty string, skips linting.
+
+  Default value: `src`
+* `-d`, `--debug` — Builds the module using debug instead of release (intended to speed up local iteration, not recommended for CI)
+
+
+
+## `spacetime server`
+
+Manage the connection to the SpacetimeDB server.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime server
+       server <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List stored server configurations
+* `set-default` — Set the default server for future operations
+* `add` — Add a new server configuration
+* `remove` — Remove a saved server configuration
+* `fingerprint` — Show or update a saved server's fingerprint
+* `ping` — Checks to see if a SpacetimeDB host is online
+* `edit` — Update a saved server's nickname, host name or protocol
+* `clear` — Deletes all data from all local databases
+
+
+
+## `spacetime server list`
+
+List stored server configurations
+
+**Usage:** `spacetime server list`
+
+
+
+## `spacetime server set-default`
+
+Set the default server for future operations
+
+**Usage:** `spacetime server set-default <server>`
+
+###### **Arguments:**
+
+* `<SERVER>` — The nickname, host name or URL of the new default server
+
+
+
+## `spacetime server add`
+
+Add a new server configuration
+
+**Usage:** `spacetime server add [OPTIONS] --url <url> <name>`
+
+###### **Arguments:**
+
+* `<NAME>` — Nickname for this server
+
+###### **Options:**
+
+* `--url <URL>` — The URL of the server to add
+* `-d`, `--default` — Make the new server the default server for future operations
+* `--no-fingerprint` — Skip fingerprinting the server
+
+
+
+## `spacetime server remove`
+
+Remove a saved server configuration
+
+**Usage:** `spacetime server remove [OPTIONS] <server>`
+
+###### **Arguments:**
+
+* `<SERVER>` — The nickname, host name or URL of the server to remove
+
+###### **Options:**
+
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime server fingerprint`
+
+Show or update a saved server's fingerprint
+
+**Usage:** `spacetime server fingerprint [OPTIONS] <server>`
+
+###### **Arguments:**
+
+* `<SERVER>` — The nickname, host name or URL of the server
+
+###### **Options:**
+
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime server ping`
+
+Checks to see if a SpacetimeDB host is online
+
+**Usage:** `spacetime server ping <server>`
+
+###### **Arguments:**
+
+* `<SERVER>` — The nickname, host name or URL of the server to ping
+
+
+
+## `spacetime server edit`
+
+Update a saved server's nickname, host name or protocol
+
+**Usage:** `spacetime server edit [OPTIONS] <server>`
+
+###### **Arguments:**
+
+* `<SERVER>` — The nickname, host name or URL of the server
+
+###### **Options:**
+
+* `--new-name <NICKNAME>` — A new nickname to assign the server configuration
+* `--url <URL>` — A new URL to assign the server configuration
+* `--no-fingerprint` — Skip fingerprinting the server
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime server clear`
+
+Deletes all data from all local databases
+
+**Usage:** `spacetime server clear [OPTIONS]`
+
+###### **Options:**
+
+* `--data-dir <DATA_DIR>` — The path to the server data directory to clear [default: that of the selected spacetime instance]
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+
+
+
+## `spacetime subscribe`
+
+Subscribe to SQL queries on the database.
+
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+**Usage:** `spacetime subscribe [OPTIONS] <database> <query>...`
+
+###### **Arguments:**
+
+* `<DATABASE>` — The name or identity of the database you would like to query
+* `<QUERY>` — The SQL query to execute
+
+###### **Options:**
+
+* `-n`, `--num-updates <NUM-UPDATES>` — The number of subscription updates to receive before exiting
+* `-t`, `--timeout <TIMEOUT>` — The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever
+                     one comes first.
+* `--print-initial-update` — Print the initial update for the queries.
+* `--anonymous` — Perform this action with an anonymous identity
+* `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
+
+
+
+## `spacetime start`
+
+Start a local SpacetimeDB instance
+
+Run `spacetime start --help` to see all options.
+
+**Usage:** `spacetime start [OPTIONS] [args]...`
+
+###### **Arguments:**
+
+* `<ARGS>` — The args to pass to `spacetimedb-{edition} start`
+
+###### **Options:**
+
+* `--edition <EDITION>` — The edition of SpacetimeDB to start up
+
+  Default value: `standalone`
+
+  Possible values: `standalone`, `cloud`
+
+
+
+
+## `spacetime version`
+
+Manage installed spacetime versions
+
+Run `spacetime version --help` to see all options.
+
+**Usage:** `spacetime version [ARGS]...`
+
+###### **Arguments:**
+
+* `<ARGS>` — The args to pass to spacetimedb-update
+
+
+
+<hr/>
+
+<small><i>
+    This document was generated automatically by
+    <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
+</i></small>

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -38,7 +38,7 @@ This document contains the help content for the `spacetime` command-line program
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
-###### Subcommands:
+###### <b>Subcommands:</b>
 
 * `publish` — Create and update a SpacetimeDB database
 * `delete` — Deletes a SpacetimeDB database
@@ -75,7 +75,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 * `start` — Start a local SpacetimeDB instance
 * `version` — Manage installed spacetime versions
 
-###### Options:
+###### <b>Options:</b>
 
 * `--root-dir <ROOT_DIR>` — The root directory to store all spacetime files in.
 * `--config-path <CONFIG_PATH>` — The path to the cli.toml config file
@@ -90,11 +90,11 @@ Create and update a SpacetimeDB database
 
 Run `spacetime help publish` for more detailed information.
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<NAME|IDENTITY>` — A valid domain or identity for this database
 
-###### Options:
+###### <b>Options:</b>
 
 * `-c`, `--delete-data` — When publishing to an existing database identity, first DESTROY all data associated with the module
 * `--build-options <BUILD_OPTIONS>` — Options to pass to the build command, for example --build-options='--skip-println-checks'
@@ -119,11 +119,11 @@ Deletes a SpacetimeDB database
 Run `spacetime help delete` for more detailed information.
 
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The name or identity of the database to delete
 
-###### Options:
+###### <b>Options:</b>
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -139,11 +139,11 @@ Prints logs from a SpacetimeDB database
 Run `spacetime help logs` for more detailed information.
 
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The name or identity of the database to print logs from
 
-###### Options:
+###### <b>Options:</b>
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-n`, `--num-lines <NUM_LINES>` — The number of lines to print from the start of the log of this database. If no num lines is provided, all lines will be returned.
@@ -169,13 +169,13 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 Run `spacetime help call` for more detailed information.
 
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The database name or identity to use to invoke the call
 * `<REDUCER_NAME>` — The name of the reducer to call
 * `<ARGUMENTS>` — arguments formatted as JSON
 
-###### Options:
+###### <b>Options:</b>
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `--anonymous` — Perform this action with an anonymous identity
@@ -194,7 +194,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 Run `spacetime help describe` for more detailed information.
 
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The name or identity of the database to describe
 * `<ENTITY_TYPE>` — Whether to describe a reducer or table
@@ -203,7 +203,7 @@ Run `spacetime help describe` for more detailed information.
 
 * `<ENTITY_NAME>` — The name of the entity to describe
 
-###### Options:
+###### <b>Options:</b>
 
 * `--json` — Output the schema in JSON format. Currently required; in the future, omitting this will give human-readable output.
 * `--anonymous` — Perform this action with an anonymous identity
@@ -221,7 +221,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 **Usage:** `spacetime energy
        energy <COMMAND>`
 
-###### Subcommands:
+###### <b>Subcommands:</b>
 
 * `balance` — Show current energy balance for an identity
 
@@ -233,7 +233,7 @@ Show current energy balance for an identity
 
 **Usage:** `spacetime energy balance [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `-i`, `--identity <IDENTITY>` — The identity to check the balance for. If no identity is provided, the default one will be used.
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to request balance information
@@ -249,12 +249,12 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime sql [OPTIONS] <database> <query>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The name or identity of the database you would like to query
 * `<QUERY>` — The SQL query to execute
 
-###### Options:
+###### <b>Options:</b>
 
 * `--interactive` — Instead of using a query, run an interactive command prompt for `SQL` expressions
 * `--anonymous` — Perform this action with an anonymous identity
@@ -272,11 +272,11 @@ Rename a database
 Run `spacetime rename --help` for more detailed information.
 
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE-IDENTITY>` — The database identity to rename
 
-###### Options:
+###### <b>Options:</b>
 
 * `--to <NEW-NAME>` — The new name you would like to assign
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server on which to set the name
@@ -292,7 +292,7 @@ Generate client files for a spacetime module.
 
 Run `spacetime help publish` for more detailed information.
 
-###### Options:
+###### <b>Options:</b>
 
 * `-b`, `--bin-path <WASM_FILE>` — The system path (absolute or relative) to the compiled wasm binary we should inspect
 * `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to inspect
@@ -321,7 +321,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime list [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to list databases
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -335,11 +335,11 @@ Manage your login to the SpacetimeDB CLI
 **Usage:** `spacetime login [OPTIONS]
        login <COMMAND>`
 
-###### Subcommands:
+###### <b>Subcommands:</b>
 
 * `show` — Show the current login info
 
-###### Options:
+###### <b>Options:</b>
 
 * `--auth-host <AUTH-HOST>` — Fetch login token from a different host
 
@@ -355,7 +355,7 @@ Show the current login info
 
 **Usage:** `spacetime login show [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `--token` — Also show the auth token
 
@@ -365,7 +365,7 @@ Show the current login info
 
 **Usage:** `spacetime logout [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `--auth-host <AUTH-HOST>` — Log out from a custom auth server
 
@@ -381,13 +381,13 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime init --lang <lang> [project-path]`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<PROJECT-PATH>` — The path where we will create the spacetime project
 
   Default value: `.`
 
-###### Options:
+###### <b>Options:</b>
 
 * `-l`, `--lang <LANG>` — The spacetime module language.
 
@@ -402,7 +402,7 @@ Builds a spacetime module.
 
 **Usage:** `spacetime build [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to build
 
@@ -423,7 +423,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 **Usage:** `spacetime server
        server <COMMAND>`
 
-###### Subcommands:
+###### <b>Subcommands:</b>
 
 * `list` — List stored server configurations
 * `set-default` — Set the default server for future operations
@@ -450,7 +450,7 @@ Set the default server for future operations
 
 **Usage:** `spacetime server set-default <server>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<SERVER>` — The nickname, host name or URL of the new default server
 
@@ -462,11 +462,11 @@ Add a new server configuration
 
 **Usage:** `spacetime server add [OPTIONS] --url <url> <name>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<NAME>` — Nickname for this server
 
-###### Options:
+###### <b>Options:</b>
 
 * `--url <URL>` — The URL of the server to add
 * `-d`, `--default` — Make the new server the default server for future operations
@@ -480,11 +480,11 @@ Remove a saved server configuration
 
 **Usage:** `spacetime server remove [OPTIONS] <server>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<SERVER>` — The nickname, host name or URL of the server to remove
 
-###### Options:
+###### <b>Options:</b>
 
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
 
@@ -496,11 +496,11 @@ Show or update a saved server's fingerprint
 
 **Usage:** `spacetime server fingerprint [OPTIONS] <server>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<SERVER>` — The nickname, host name or URL of the server
 
-###### Options:
+###### <b>Options:</b>
 
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
 
@@ -512,7 +512,7 @@ Checks to see if a SpacetimeDB host is online
 
 **Usage:** `spacetime server ping <server>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<SERVER>` — The nickname, host name or URL of the server to ping
 
@@ -524,11 +524,11 @@ Update a saved server's nickname, host name or protocol
 
 **Usage:** `spacetime server edit [OPTIONS] <server>`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<SERVER>` — The nickname, host name or URL of the server
 
-###### Options:
+###### <b>Options:</b>
 
 * `--new-name <NICKNAME>` — A new nickname to assign the server configuration
 * `--url <URL>` — A new URL to assign the server configuration
@@ -543,7 +543,7 @@ Deletes all data from all local databases
 
 **Usage:** `spacetime server clear [OPTIONS]`
 
-###### Options:
+###### <b>Options:</b>
 
 * `--data-dir <DATA_DIR>` — The path to the server data directory to clear [default: that of the selected spacetime instance]
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -558,12 +558,12 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime subscribe [OPTIONS] <database> <query>...`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<DATABASE>` — The name or identity of the database you would like to query
 * `<QUERY>` — The SQL query to execute
 
-###### Options:
+###### <b>Options:</b>
 
 * `-n`, `--num-updates <NUM-UPDATES>` — The number of subscription updates to receive before exiting
 * `-t`, `--timeout <TIMEOUT>` — The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever
@@ -583,11 +583,11 @@ Run `spacetime start --help` to see all options.
 
 **Usage:** `spacetime start [OPTIONS] [args]...`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<ARGS>` — The args to pass to `spacetimedb-{edition} start`
 
-###### Options:
+###### <b>Options:</b>
 
 * `--edition <EDITION>` — The edition of SpacetimeDB to start up
 
@@ -606,7 +606,7 @@ Run `spacetime version --help` to see all options.
 
 **Usage:** `spacetime version [ARGS]...`
 
-###### Arguments:
+###### <b>Arguments:</b>
 
 * `<ARGS>` — The args to pass to spacetimedb-update
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -43,35 +43,19 @@ This document contains the help content for the `spacetime` command-line program
 * `publish` — Create and update a SpacetimeDB database
 * `delete` — Deletes a SpacetimeDB database
 * `logs` — Prints logs from a SpacetimeDB database
-* `call` — Invokes a reducer function in a database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
-* `describe` — Describe the structure of a database or entities within it.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
-* `energy` — Invokes commands related to database budgets.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
-* `sql` — Runs a SQL query on the database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+* `call` — Invokes a reducer function in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `describe` — Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `energy` — Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `sql` — Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `rename` — Rename a database
 * `generate` — Generate client files for a spacetime module.
-* `list` — Lists the databases attached to an identity.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+* `list` — Lists the databases attached to an identity. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `login` — Manage your login to the SpacetimeDB CLI
 * `logout` — 
-* `init` — Initializes a new spacetime project.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+* `init` — Initializes a new spacetime project. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `build` — Builds a spacetime module.
-* `server` — Manage the connection to the SpacetimeDB server.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
-* `subscribe` — Subscribe to SQL queries on the database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+* `server` — Manage the connection to the SpacetimeDB server. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `subscribe` — Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `start` — Start a local SpacetimeDB instance
 * `version` — Manage installed spacetime versions
 
@@ -160,9 +144,7 @@ Run `spacetime help logs` for more detailed information.
 
 ## spacetime call
 
-Invokes a reducer function in a database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Invokes a reducer function in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime call [OPTIONS] <database> <reducer_name> [arguments]...`
 
@@ -185,9 +167,7 @@ Run `spacetime help call` for more detailed information.
 
 ## spacetime describe
 
-Describe the structure of a database or entities within it.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime describe [OPTIONS] --json <database> [entity_type] [entity_name]`
 
@@ -214,9 +194,7 @@ Run `spacetime help describe` for more detailed information.
 
 ## spacetime energy
 
-Invokes commands related to database budgets.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime energy
        energy <COMMAND>`
@@ -243,9 +221,7 @@ Show current energy balance for an identity
 
 ## spacetime sql
 
-Runs a SQL query on the database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime sql [OPTIONS] <database> <query>`
 
@@ -315,9 +291,7 @@ Run `spacetime help publish` for more detailed information.
 
 ## spacetime list
 
-Lists the databases attached to an identity.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Lists the databases attached to an identity. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime list [OPTIONS]`
 
@@ -375,9 +349,7 @@ Show the current login info
 
 ## spacetime init
 
-Initializes a new spacetime project.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Initializes a new spacetime project. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime init --lang <lang> [project-path]`
 
@@ -416,9 +388,7 @@ Builds a spacetime module.
 
 ## spacetime server
 
-Manage the connection to the SpacetimeDB server.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Manage the connection to the SpacetimeDB server. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime server
        server <COMMAND>`
@@ -552,9 +522,7 @@ Deletes all data from all local databases
 
 ## spacetime subscribe
 
-Subscribe to SQL queries on the database.
-
-WARNING: This command is UNSTABLE and subject to breaking changes.
+Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime subscribe [OPTIONS] <database> <query>...`
 
@@ -618,3 +586,4 @@ Run `spacetime version --help` to see all options.
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ This document contains the help content for the `spacetime` command-line program
 * [`spacetime start`↴](#spacetime-start)
 * [`spacetime version`↴](#spacetime-version)
 
-## `spacetime`
+## <pre><code>spacetime</code><pre>
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
@@ -82,7 +82,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime publish`
+## <pre><code>spacetime publish</code><pre>
 
 Create and update a SpacetimeDB database
 
@@ -110,7 +110,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## `spacetime delete`
+## <pre><code>spacetime delete</code><pre>
 
 Deletes a SpacetimeDB database
 
@@ -130,7 +130,7 @@ Run `spacetime help delete` for more detailed information.
 
 
 
-## `spacetime logs`
+## <pre><code>spacetime logs</code><pre>
 
 Prints logs from a SpacetimeDB database
 
@@ -158,7 +158,7 @@ Run `spacetime help logs` for more detailed information.
 
 
 
-## `spacetime call`
+## <pre><code>spacetime call</code><pre>
 
 Invokes a reducer function in a database.
 
@@ -183,7 +183,7 @@ Run `spacetime help call` for more detailed information.
 
 
 
-## `spacetime describe`
+## <pre><code>spacetime describe</code><pre>
 
 Describe the structure of a database or entities within it.
 
@@ -212,7 +212,7 @@ Run `spacetime help describe` for more detailed information.
 
 
 
-## `spacetime energy`
+## <pre><code>spacetime energy</code><pre>
 
 Invokes commands related to database budgets.
 
@@ -227,7 +227,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime energy balance`
+## <pre><code>spacetime energy balance</code><pre>
 
 Show current energy balance for an identity
 
@@ -241,7 +241,7 @@ Show current energy balance for an identity
 
 
 
-## `spacetime sql`
+## <pre><code>spacetime sql</code><pre>
 
 Runs a SQL query on the database.
 
@@ -263,7 +263,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime rename`
+## <pre><code>spacetime rename</code><pre>
 
 Rename a database
 
@@ -284,7 +284,7 @@ Run `spacetime rename --help` for more detailed information.
 
 
 
-## `spacetime generate`
+## <pre><code>spacetime generate</code><pre>
 
 Generate client files for a spacetime module.
 
@@ -313,7 +313,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## `spacetime list`
+## <pre><code>spacetime list</code><pre>
 
 Lists the databases attached to an identity.
 
@@ -328,7 +328,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime login`
+## <pre><code>spacetime login</code><pre>
 
 Manage your login to the SpacetimeDB CLI
 
@@ -349,7 +349,7 @@ Manage your login to the SpacetimeDB CLI
 
 
 
-## `spacetime login show`
+## <pre><code>spacetime login show</code><pre>
 
 Show the current login info
 
@@ -361,7 +361,7 @@ Show the current login info
 
 
 
-## `spacetime logout`
+## <pre><code>spacetime logout</code><pre>
 
 **Usage:** `spacetime logout [OPTIONS]`
 
@@ -373,7 +373,7 @@ Show the current login info
 
 
 
-## `spacetime init`
+## <pre><code>spacetime init</code><pre>
 
 Initializes a new spacetime project.
 
@@ -396,7 +396,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime build`
+## <pre><code>spacetime build</code><pre>
 
 Builds a spacetime module.
 
@@ -414,7 +414,7 @@ Builds a spacetime module.
 
 
 
-## `spacetime server`
+## <pre><code>spacetime server</code><pre>
 
 Manage the connection to the SpacetimeDB server.
 
@@ -436,7 +436,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime server list`
+## <pre><code>spacetime server list</code><pre>
 
 List stored server configurations
 
@@ -444,7 +444,7 @@ List stored server configurations
 
 
 
-## `spacetime server set-default`
+## <pre><code>spacetime server set-default</code><pre>
 
 Set the default server for future operations
 
@@ -456,7 +456,7 @@ Set the default server for future operations
 
 
 
-## `spacetime server add`
+## <pre><code>spacetime server add</code><pre>
 
 Add a new server configuration
 
@@ -474,7 +474,7 @@ Add a new server configuration
 
 
 
-## `spacetime server remove`
+## <pre><code>spacetime server remove</code><pre>
 
 Remove a saved server configuration
 
@@ -490,7 +490,7 @@ Remove a saved server configuration
 
 
 
-## `spacetime server fingerprint`
+## <pre><code>spacetime server fingerprint</code><pre>
 
 Show or update a saved server's fingerprint
 
@@ -506,7 +506,7 @@ Show or update a saved server's fingerprint
 
 
 
-## `spacetime server ping`
+## <pre><code>spacetime server ping</code><pre>
 
 Checks to see if a SpacetimeDB host is online
 
@@ -518,7 +518,7 @@ Checks to see if a SpacetimeDB host is online
 
 
 
-## `spacetime server edit`
+## <pre><code>spacetime server edit</code><pre>
 
 Update a saved server's nickname, host name or protocol
 
@@ -537,7 +537,7 @@ Update a saved server's nickname, host name or protocol
 
 
 
-## `spacetime server clear`
+## <pre><code>spacetime server clear</code><pre>
 
 Deletes all data from all local databases
 
@@ -550,7 +550,7 @@ Deletes all data from all local databases
 
 
 
-## `spacetime subscribe`
+## <pre><code>spacetime subscribe</code><pre>
 
 Subscribe to SQL queries on the database.
 
@@ -575,7 +575,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## `spacetime start`
+## <pre><code>spacetime start</code><pre>
 
 Start a local SpacetimeDB instance
 
@@ -598,7 +598,7 @@ Run `spacetime start --help` to see all options.
 
 
 
-## `spacetime version`
+## <pre><code>spacetime version</code><pre>
 
 Manage installed spacetime versions
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,7 +34,7 @@ This document contains the help content for the `spacetime` command-line program
 * [`spacetime start`↴](#spacetime-start)
 * [`spacetime version`↴](#spacetime-version)
 
-## <pre><code>spacetime</code></pre>
+## <code>spacetime</code>
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
@@ -82,7 +82,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime publish</code></pre>
+## <code>spacetime publish</code>
 
 Create and update a SpacetimeDB database
 
@@ -110,7 +110,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <pre><code>spacetime delete</code></pre>
+## <code>spacetime delete</code>
 
 Deletes a SpacetimeDB database
 
@@ -130,7 +130,7 @@ Run `spacetime help delete` for more detailed information.
 
 
 
-## <pre><code>spacetime logs</code></pre>
+## <code>spacetime logs</code>
 
 Prints logs from a SpacetimeDB database
 
@@ -158,7 +158,7 @@ Run `spacetime help logs` for more detailed information.
 
 
 
-## <pre><code>spacetime call</code></pre>
+## <code>spacetime call</code>
 
 Invokes a reducer function in a database.
 
@@ -183,7 +183,7 @@ Run `spacetime help call` for more detailed information.
 
 
 
-## <pre><code>spacetime describe</code></pre>
+## <code>spacetime describe</code>
 
 Describe the structure of a database or entities within it.
 
@@ -212,7 +212,7 @@ Run `spacetime help describe` for more detailed information.
 
 
 
-## <pre><code>spacetime energy</code></pre>
+## <code>spacetime energy</code>
 
 Invokes commands related to database budgets.
 
@@ -227,7 +227,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime energy balance</code></pre>
+## <code>spacetime energy balance</code>
 
 Show current energy balance for an identity
 
@@ -241,7 +241,7 @@ Show current energy balance for an identity
 
 
 
-## <pre><code>spacetime sql</code></pre>
+## <code>spacetime sql</code>
 
 Runs a SQL query on the database.
 
@@ -263,7 +263,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime rename</code></pre>
+## <code>spacetime rename</code>
 
 Rename a database
 
@@ -284,7 +284,7 @@ Run `spacetime rename --help` for more detailed information.
 
 
 
-## <pre><code>spacetime generate</code></pre>
+## <code>spacetime generate</code>
 
 Generate client files for a spacetime module.
 
@@ -313,7 +313,7 @@ Run `spacetime help publish` for more detailed information.
 
 
 
-## <pre><code>spacetime list</code></pre>
+## <code>spacetime list</code>
 
 Lists the databases attached to an identity.
 
@@ -328,7 +328,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime login</code></pre>
+## <code>spacetime login</code>
 
 Manage your login to the SpacetimeDB CLI
 
@@ -349,7 +349,7 @@ Manage your login to the SpacetimeDB CLI
 
 
 
-## <pre><code>spacetime login show</code></pre>
+## <code>spacetime login show</code>
 
 Show the current login info
 
@@ -361,7 +361,7 @@ Show the current login info
 
 
 
-## <pre><code>spacetime logout</code></pre>
+## <code>spacetime logout</code>
 
 **Usage:** `spacetime logout [OPTIONS]`
 
@@ -373,7 +373,7 @@ Show the current login info
 
 
 
-## <pre><code>spacetime init</code></pre>
+## <code>spacetime init</code>
 
 Initializes a new spacetime project.
 
@@ -396,7 +396,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime build</code></pre>
+## <code>spacetime build</code>
 
 Builds a spacetime module.
 
@@ -414,7 +414,7 @@ Builds a spacetime module.
 
 
 
-## <pre><code>spacetime server</code></pre>
+## <code>spacetime server</code>
 
 Manage the connection to the SpacetimeDB server.
 
@@ -436,7 +436,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime server list</code></pre>
+## <code>spacetime server list</code>
 
 List stored server configurations
 
@@ -444,7 +444,7 @@ List stored server configurations
 
 
 
-## <pre><code>spacetime server set-default</code></pre>
+## <code>spacetime server set-default</code>
 
 Set the default server for future operations
 
@@ -456,7 +456,7 @@ Set the default server for future operations
 
 
 
-## <pre><code>spacetime server add</code></pre>
+## <code>spacetime server add</code>
 
 Add a new server configuration
 
@@ -474,7 +474,7 @@ Add a new server configuration
 
 
 
-## <pre><code>spacetime server remove</code></pre>
+## <code>spacetime server remove</code>
 
 Remove a saved server configuration
 
@@ -490,7 +490,7 @@ Remove a saved server configuration
 
 
 
-## <pre><code>spacetime server fingerprint</code></pre>
+## <code>spacetime server fingerprint</code>
 
 Show or update a saved server's fingerprint
 
@@ -506,7 +506,7 @@ Show or update a saved server's fingerprint
 
 
 
-## <pre><code>spacetime server ping</code></pre>
+## <code>spacetime server ping</code>
 
 Checks to see if a SpacetimeDB host is online
 
@@ -518,7 +518,7 @@ Checks to see if a SpacetimeDB host is online
 
 
 
-## <pre><code>spacetime server edit</code></pre>
+## <code>spacetime server edit</code>
 
 Update a saved server's nickname, host name or protocol
 
@@ -537,7 +537,7 @@ Update a saved server's nickname, host name or protocol
 
 
 
-## <pre><code>spacetime server clear</code></pre>
+## <code>spacetime server clear</code>
 
 Deletes all data from all local databases
 
@@ -550,7 +550,7 @@ Deletes all data from all local databases
 
 
 
-## <pre><code>spacetime subscribe</code></pre>
+## <code>spacetime subscribe</code>
 
 Subscribe to SQL queries on the database.
 
@@ -575,7 +575,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 
 
-## <pre><code>spacetime start</code></pre>
+## <code>spacetime start</code>
 
 Start a local SpacetimeDB instance
 
@@ -598,7 +598,7 @@ Run `spacetime start --help` to see all options.
 
 
 
-## <pre><code>spacetime version</code></pre>
+## <code>spacetime version</code>
 
 Manage installed spacetime versions
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -38,7 +38,7 @@ This document contains the help content for the `spacetime` command-line program
 
 **Usage:** `spacetime [OPTIONS] <COMMAND>`
 
-###### **Subcommands:**
+###### Subcommands:
 
 * `publish` — Create and update a SpacetimeDB database
 * `delete` — Deletes a SpacetimeDB database
@@ -75,7 +75,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 * `start` — Start a local SpacetimeDB instance
 * `version` — Manage installed spacetime versions
 
-###### **Options:**
+###### Options:
 
 * `--root-dir <ROOT_DIR>` — The root directory to store all spacetime files in.
 * `--config-path <CONFIG_PATH>` — The path to the cli.toml config file
@@ -90,11 +90,11 @@ Create and update a SpacetimeDB database
 
 Run `spacetime help publish` for more detailed information.
 
-###### **Arguments:**
+###### Arguments:
 
 * `<NAME|IDENTITY>` — A valid domain or identity for this database
 
-###### **Options:**
+###### Options:
 
 * `-c`, `--delete-data` — When publishing to an existing database identity, first DESTROY all data associated with the module
 * `--build-options <BUILD_OPTIONS>` — Options to pass to the build command, for example --build-options='--skip-println-checks'
@@ -119,11 +119,11 @@ Deletes a SpacetimeDB database
 Run `spacetime help delete` for more detailed information.
 
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The name or identity of the database to delete
 
-###### **Options:**
+###### Options:
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -139,11 +139,11 @@ Prints logs from a SpacetimeDB database
 Run `spacetime help logs` for more detailed information.
 
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The name or identity of the database to print logs from
 
-###### **Options:**
+###### Options:
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-n`, `--num-lines <NUM_LINES>` — The number of lines to print from the start of the log of this database. If no num lines is provided, all lines will be returned.
@@ -169,13 +169,13 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 Run `spacetime help call` for more detailed information.
 
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The database name or identity to use to invoke the call
 * `<REDUCER_NAME>` — The name of the reducer to call
 * `<ARGUMENTS>` — arguments formatted as JSON
 
-###### **Options:**
+###### Options:
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `--anonymous` — Perform this action with an anonymous identity
@@ -194,7 +194,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 Run `spacetime help describe` for more detailed information.
 
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The name or identity of the database to describe
 * `<ENTITY_TYPE>` — Whether to describe a reducer or table
@@ -203,7 +203,7 @@ Run `spacetime help describe` for more detailed information.
 
 * `<ENTITY_NAME>` — The name of the entity to describe
 
-###### **Options:**
+###### Options:
 
 * `--json` — Output the schema in JSON format. Currently required; in the future, omitting this will give human-readable output.
 * `--anonymous` — Perform this action with an anonymous identity
@@ -221,7 +221,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 **Usage:** `spacetime energy
        energy <COMMAND>`
 
-###### **Subcommands:**
+###### Subcommands:
 
 * `balance` — Show current energy balance for an identity
 
@@ -233,7 +233,7 @@ Show current energy balance for an identity
 
 **Usage:** `spacetime energy balance [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `-i`, `--identity <IDENTITY>` — The identity to check the balance for. If no identity is provided, the default one will be used.
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to request balance information
@@ -249,12 +249,12 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime sql [OPTIONS] <database> <query>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The name or identity of the database you would like to query
 * `<QUERY>` — The SQL query to execute
 
-###### **Options:**
+###### Options:
 
 * `--interactive` — Instead of using a query, run an interactive command prompt for `SQL` expressions
 * `--anonymous` — Perform this action with an anonymous identity
@@ -272,11 +272,11 @@ Rename a database
 Run `spacetime rename --help` for more detailed information.
 
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE-IDENTITY>` — The database identity to rename
 
-###### **Options:**
+###### Options:
 
 * `--to <NEW-NAME>` — The new name you would like to assign
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server on which to set the name
@@ -292,7 +292,7 @@ Generate client files for a spacetime module.
 
 Run `spacetime help publish` for more detailed information.
 
-###### **Options:**
+###### Options:
 
 * `-b`, `--bin-path <WASM_FILE>` — The system path (absolute or relative) to the compiled wasm binary we should inspect
 * `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to inspect
@@ -321,7 +321,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime list [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server from which to list databases
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -335,11 +335,11 @@ Manage your login to the SpacetimeDB CLI
 **Usage:** `spacetime login [OPTIONS]
        login <COMMAND>`
 
-###### **Subcommands:**
+###### Subcommands:
 
 * `show` — Show the current login info
 
-###### **Options:**
+###### Options:
 
 * `--auth-host <AUTH-HOST>` — Fetch login token from a different host
 
@@ -355,7 +355,7 @@ Show the current login info
 
 **Usage:** `spacetime login show [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `--token` — Also show the auth token
 
@@ -365,7 +365,7 @@ Show the current login info
 
 **Usage:** `spacetime logout [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `--auth-host <AUTH-HOST>` — Log out from a custom auth server
 
@@ -381,13 +381,13 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime init --lang <lang> [project-path]`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<PROJECT-PATH>` — The path where we will create the spacetime project
 
   Default value: `.`
 
-###### **Options:**
+###### Options:
 
 * `-l`, `--lang <LANG>` — The spacetime module language.
 
@@ -402,7 +402,7 @@ Builds a spacetime module.
 
 **Usage:** `spacetime build [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `-p`, `--project-path <PROJECT_PATH>` — The system path (absolute or relative) to the project you would like to build
 
@@ -423,7 +423,7 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 **Usage:** `spacetime server
        server <COMMAND>`
 
-###### **Subcommands:**
+###### Subcommands:
 
 * `list` — List stored server configurations
 * `set-default` — Set the default server for future operations
@@ -450,7 +450,7 @@ Set the default server for future operations
 
 **Usage:** `spacetime server set-default <server>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<SERVER>` — The nickname, host name or URL of the new default server
 
@@ -462,11 +462,11 @@ Add a new server configuration
 
 **Usage:** `spacetime server add [OPTIONS] --url <url> <name>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<NAME>` — Nickname for this server
 
-###### **Options:**
+###### Options:
 
 * `--url <URL>` — The URL of the server to add
 * `-d`, `--default` — Make the new server the default server for future operations
@@ -480,11 +480,11 @@ Remove a saved server configuration
 
 **Usage:** `spacetime server remove [OPTIONS] <server>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<SERVER>` — The nickname, host name or URL of the server to remove
 
-###### **Options:**
+###### Options:
 
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
 
@@ -496,11 +496,11 @@ Show or update a saved server's fingerprint
 
 **Usage:** `spacetime server fingerprint [OPTIONS] <server>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<SERVER>` — The nickname, host name or URL of the server
 
-###### **Options:**
+###### Options:
 
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
 
@@ -512,7 +512,7 @@ Checks to see if a SpacetimeDB host is online
 
 **Usage:** `spacetime server ping <server>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<SERVER>` — The nickname, host name or URL of the server to ping
 
@@ -524,11 +524,11 @@ Update a saved server's nickname, host name or protocol
 
 **Usage:** `spacetime server edit [OPTIONS] <server>`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<SERVER>` — The nickname, host name or URL of the server
 
-###### **Options:**
+###### Options:
 
 * `--new-name <NICKNAME>` — A new nickname to assign the server configuration
 * `--url <URL>` — A new URL to assign the server configuration
@@ -543,7 +543,7 @@ Deletes all data from all local databases
 
 **Usage:** `spacetime server clear [OPTIONS]`
 
-###### **Options:**
+###### Options:
 
 * `--data-dir <DATA_DIR>` — The path to the server data directory to clear [default: that of the selected spacetime instance]
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
@@ -558,12 +558,12 @@ WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime subscribe [OPTIONS] <database> <query>...`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<DATABASE>` — The name or identity of the database you would like to query
 * `<QUERY>` — The SQL query to execute
 
-###### **Options:**
+###### Options:
 
 * `-n`, `--num-updates <NUM-UPDATES>` — The number of subscription updates to receive before exiting
 * `-t`, `--timeout <TIMEOUT>` — The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever
@@ -583,11 +583,11 @@ Run `spacetime start --help` to see all options.
 
 **Usage:** `spacetime start [OPTIONS] [args]...`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<ARGS>` — The args to pass to `spacetimedb-{edition} start`
 
-###### **Options:**
+###### Options:
 
 * `--edition <EDITION>` — The edition of SpacetimeDB to start up
 
@@ -606,7 +606,7 @@ Run `spacetime version --help` to see all options.
 
 **Usage:** `spacetime version [ARGS]...`
 
-###### **Arguments:**
+###### Arguments:
 
 * `<ARGS>` — The args to pass to spacetimedb-update
 

--- a/docs/nav.js
+++ b/docs/nav.js
@@ -20,7 +20,7 @@ const nav = {
         page('3 - Gameplay', 'unity/part-3', 'unity/part-3.md'),
         page('4 - Moving and Colliding', 'unity/part-4', 'unity/part-4.md'),
         section('CLI Reference'),
-        page('CLI Reference' 'cli-reference', 'cli-reference.md'),
+        page('CLI Reference', 'cli-reference', 'cli-reference.md'),
         section('Server Module Languages'),
         page('Overview', 'modules', 'modules/index.md'),
         page('Rust Quickstart', 'modules/rust/quickstart', 'modules/rust/quickstart.md'),

--- a/docs/nav.js
+++ b/docs/nav.js
@@ -19,6 +19,8 @@ const nav = {
         page('2 - Connecting to SpacetimeDB', 'unity/part-2', 'unity/part-2.md'),
         page('3 - Gameplay', 'unity/part-3', 'unity/part-3.md'),
         page('4 - Moving and Colliding', 'unity/part-4', 'unity/part-4.md'),
+        section('CLI Reference'),
+        page('CLI Reference' 'cli-reference', 'cli-reference.md'),
         section('Server Module Languages'),
         page('Overview', 'modules', 'modules/index.md'),
         page('Rust Quickstart', 'modules/rust/quickstart', 'modules/rust/quickstart.md'),

--- a/nav.ts
+++ b/nav.ts
@@ -47,7 +47,7 @@ const nav: Nav = {
     page('4 - Moving and Colliding', 'unity/part-4', 'unity/part-4.md'),
 
     section('CLI Reference'),
-    page('CLI Reference' 'cli-reference', 'cli-reference.md'),
+    page('CLI Reference', 'cli-reference', 'cli-reference.md'),
 
     section('Server Module Languages'),
     page('Overview', 'modules', 'modules/index.md'),

--- a/nav.ts
+++ b/nav.ts
@@ -46,6 +46,9 @@ const nav: Nav = {
     page('3 - Gameplay', 'unity/part-3', 'unity/part-3.md'),
     page('4 - Moving and Colliding', 'unity/part-4', 'unity/part-4.md'),
 
+    section('CLI Reference'),
+    page('CLI Reference' 'cli-reference', 'cli-reference.md'),
+
     section('Server Module Languages'),
     page('Overview', 'modules', 'modules/index.md'),
     page(


### PR DESCRIPTION
Add a CLI reference section.

It looks roughly like this:
![image](https://github.com/user-attachments/assets/c6199d30-ef10-463a-9e3b-77d3d6a60838)

I think we could do a lot of styling improvements here, but I think this is at least "acceptable", so I think we should merge this and iterate from there.

## Note:
This depends on https://github.com/clockworklabs/SpacetimeDB/pull/2276 in order to generate it. Instructions are in the README.

I had to do some manual tweaking of the markdown because our website doesn't seem to quite parse it properly in headers. I've documented those steps in the README as well.

# Testing
If you want to check it out yourself, point your `spacetime-web` repo at `bfops/cli-docs` and go to `http://localhost:5173/docs/cli-reference`

- [x] The `spacetime publish` link at the top of the page does successfully scroll to the right section