### PR TITLE
Multiplayer bug fix in tutorial

### DIFF
--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -505,12 +505,13 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
     // Handle player input
     foreach (var circle in ctx.Db.circle.Iter())
     {
-        var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id);
-        if (circle_entity == null)
+        var check_entity = ctx.Db.entity.entity_id.Find(circle.entity_id);
+        if (check_entity == null)
         {
-            // This can happen if a circle is eaten by another circle
+            // This can happen if the circle has been eaten by another circle.
             continue;
         }
+        var circle_entity = check_entity.Value;
         var circle_radius = MassToRadius(circle_entity.mass);
         var direction = circle.direction * circle.speed;
         var new_pos = circle_entity.position + direction * MassToMaxMoveSpeed(circle_entity.mass);

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -423,7 +423,12 @@ pub fn move_all_players(ctx: &ReducerContext, _timer: MoveAllPlayersTimer) -> Re
 
     // Handle player input
     for circle in ctx.db.circle().iter() {
-        let mut circle_entity = ctx.db.entity().entity_id().find(&circle.entity_id).unwrap();
+        let circle_entity = ctx.db.entity().entity_id().find(&circle.entity_id);
+        if !circle_entity.is_some() {
+            // This can happen if a circle is eaten by another circle
+            continue;
+        }
+        let mut circle_entity = circle_entity.unwrap();
         let circle_radius = mass_to_radius(circle_entity.mass);
         let direction = circle.direction * circle.speed;
         let new_pos =
@@ -500,7 +505,12 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
     // Handle player input
     foreach (var circle in ctx.Db.circle.Iter())
     {
-        var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id) ?? throw new Exception("Circle has no entity");
+        var circle_entity = ctx.Db.entity.entity_id.Find(circle.entity_id);
+        if (circle_entity == null)
+        {
+            // This can happen if a circle is eaten by another circle
+            continue;
+        }
         var circle_radius = MassToRadius(circle_entity.mass);
         var direction = circle.direction * circle.speed;
         var new_pos = circle_entity.position + direction * MassToMaxMoveSpeed(circle_entity.mass);

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -342,43 +342,42 @@ spacetime generate --lang csharp --out-dir ../client-unity/Assets/autogen
 All that's left is to modify our `PlayerController` on the client to call the `update_player_input` reducer. Open `PlayerController.cs` and add an `Update` function:
 
 ```cs
-    public void Update()
+public void Update()
+{
+    if (!IsLocalPlayer || NumberOfOwnedCircles == 0)
     {
-        if (!IsLocalPlayer || NumberOfOwnedCircles == 0)
+        return;
+    }
+
+    if (Input.GetKeyDown(KeyCode.Q))
+    {
+        if (LockInputPosition.HasValue)
         {
-            return;
+            LockInputPosition = null;
         }
-
-        if (Input.GetKeyDown(KeyCode.Q))
+        else
         {
-            if (LockInputPosition.HasValue)
-            {
-                LockInputPosition = null;
-			}
-            else
-            {
-				LockInputPosition = (Vector2)Input.mousePosition;
-            }
+            LockInputPosition = (Vector2)Input.mousePosition;
         }
+    }
 
-        // Throttled input requests
-        if (Time.time - LastMovementSendTimestamp >= SEND_UPDATES_FREQUENCY)
+    // Throttled input requests
+    if (Time.time - LastMovementSendTimestamp >= SEND_UPDATES_FREQUENCY)
+    {
+        LastMovementSendTimestamp = Time.time;
+
+        var mousePosition = LockInputPosition ?? (Vector2)Input.mousePosition;
+        var screenSize = new Vector2
         {
-            LastMovementSendTimestamp = Time.time;
+            x = Screen.width,
+            y = Screen.height,
+        };
+        var centerOfScreen = screenSize / 2;
 
-            var mousePosition = LockInputPosition ?? (Vector2)Input.mousePosition;
-            var screenSize = new Vector2
-            {
-                x = Screen.width,
-                y = Screen.height,
-            };
-            var centerOfScreen = screenSize / 2;
-
-			var direction = (mousePosition - centerOfScreen) / (screenSize.y / 3);
-            if (testInputEnabled) { direction = testInput; }
-            GameManager.Conn.Reducers.UpdatePlayerInput(direction);
-        }
-	}
+        var direction = (mousePosition - centerOfScreen) / (screenSize.y / 3);
+        GameManager.Conn.Reducers.UpdatePlayerInput(direction);
+    }
+}
 ```
 
 Let's try it out! Press play and roam freely around the arena! Now we're cooking with gas.

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -375,6 +375,7 @@ public void Update()
         var centerOfScreen = screenSize / 2;
 
         var direction = (mousePosition - centerOfScreen) / (screenSize.y / 3);
+        if (testInputEnabled) { direction = testInput; }
         GameManager.Conn.Reducers.UpdatePlayerInput(direction);
     }
 }


### PR DESCRIPTION
Me and Beau tried to play the tutorial in multiplayer and we encountered this bug. In SpacetimeDB we were getting these logs:
```
2025-02-18T22:14:21.440945Z  INFO /home/ubuntu/actions-runner-linux-x64-2.309.0/_work/SpacetimeDB/SpacetimeDB/crates/core/src/host/wasm_common/module_host_actor.rs:504: reducer returned error: System.Exception: Circle has no entity
   at Module.MoveAllPlayers(ReducerContext , MoveAllPlayersTimer )
   at ModuleRegistration.MoveAllPlayers.Invoke(BinaryReader , IReducerContext )
   at SpacetimeDB.Internal.Module.__call_reducer__(UInt32 id, UInt64 sender_0, UInt64 sender_1, UInt64 sender_2, UInt64 sender_3, UInt64 address_0, UInt64 address_1, DateTimeOffsetRepr timestamp, BytesSource args, BytesSink error)
```

## Testing

- In progress: I am currently testing both the C# and rust modules for correctness.