### PR TITLE
Update TypeScript SDK reference

### DIFF
--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -2,9 +2,21 @@
 
 The SpacetimeDB client SDK for TypeScript contains all the tools you need to build clients for SpacetimeDB modules using Typescript, either in the browser or with NodeJS.
 
-> You need a database created before use the client, so make sure to follow the Rust or C# Module Quickstart guides if need one.
+| Name                                                              | Description                                                                                                                            |
+|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| [Project setup](#project-setup)                                   | Configure a Rust crate to use the SpacetimeDB Rust client SDK.                                                                         |
+| [Generate module bindings](#generate-module-bindings)             | Use the SpacetimeDB CLI to generate module-specific types and interfaces.                                                              |
+| [`DbConnection` type](#type-dbconnection)                         | A connection to a remote database.                                                                                                     |
+| [`DbContext` trait](#trait-dbcontext)                             | Methods for interacting with the remote database. Implemented by [`DbConnection`](#type-dbconnection) and various event context types. |
+| [`EventContext` type](#type-eventcontext)                         | [`DbContext`](#trait-dbcontext) available in [row callbacks](#callback-on_insert).                                                     |
+| [`ReducerEventContext` type](#type-reducereventcontext)           | [`DbContext`](#trait-dbcontext) available in [reducer callbacks](#observe-and-invoke-reducers).                                        |
+| [`SubscriptionEventContext` type](#type-subscriptioneventcontext) | [`DbContext`](#trait-dbcontext) available in [subscription-related callbacks](#subscribe-to-queries).                                  |
+| [`ErrorContext` type](#type-errorcontext)                         | [`DbContext`](#trait-dbcontext) available in error-related callbacks.                                                                  |
+| [Access the client cache](#access-the-client-cache)               | Make local queries against subscribed rows, and register [row callbacks](#callback-on_insert) to run when subscribed rows change.      |
+| [Observe and invoke reducers](#observe-and-invoke-reducers)       | Send requests to the database to run reducers, and register callbacks to run when notified of reducers.      |
+| [Identify a client](#identify-a-client)                           | Types for identifying users and client connections.                                                                                    |
 
-## Install the SDK
+## Project setup
 
 First, create a new client project, and add the following to your `tsconfig.json` file:
 
@@ -55,23 +67,7 @@ Each SpacetimeDB client depends on some bindings specific to your module. Create
 mkdir -p client/src/module_bindings
 spacetime generate --lang typescript \
     --out-dir client/src/module_bindings \
-    --project-path server
-```
-
-And now you will get the files for the `reducers` & `tables`:
-
-```bash
-quickstart-chat
-├── client
-│   ├── node_modules
-│   ├── public
-│   └── src
-|       └── module_bindings
-|           ├── add_reducer.ts
-|           ├── person.ts
-|           └── say_hello_reducer.ts
-└── server
-    └── src
+    --project-path PATH-TO-MODULE-DIRECTORY
 ```
 
 Import the `module_bindings` in your client's _main_ file:
@@ -79,903 +75,521 @@ Import the `module_bindings` in your client's _main_ file:
 ```typescript
 import { SpacetimeDBClient, Identity } from '@clockworklabs/spacetimedb-sdk';
 
-import Person from './module_bindings/person';
-import AddReducer from './module_bindings/add_reducer';
-import SayHelloReducer from './module_bindings/say_hello_reducer';
-console.log(Person, AddReducer, SayHelloReducer);
+import * as module_bindings from './module_bindings/index';
 ```
 
-> There is a known issue where if you do not use every type in your file, it will not pull them into the published build. To fix this, we are using `console.log` to force them to get pulled in.
+## Type `DbConnection`
 
-## API at a glance
-
-### Classes
-
-| Class                                           | Description                                                                  |
-| ----------------------------------------------- | ---------------------------------------------------------------------------- |
-| [`SpacetimeDBClient`](#class-spacetimedbclient) | The database client connection to a SpacetimeDB server.                      |
-| [`Identity`](#class-identity)                   | The user's public identity.                                                  |
-| [`Address`](#class-address)                     | An opaque identifier for differentiating connections by the same `Identity`. |
-| [`{Table}`](#class-table)                       | `{Table}` is a placeholder for each of the generated tables.                 |
-| [`{Reducer}`](#class-reducer)                   | `{Reducer}` is a placeholder for each of the generated reducers.             |
-
-### Class `SpacetimeDBClient`
-
-The database client connection to a SpacetimeDB server.
-
-Defined in [spacetimedb-sdk.spacetimedb](https://github.com/clockworklabs/spacetimedb-typescript-sdk/blob/main/src/spacetimedb.ts):
-
-| Constructors                                                      | Description                                                              |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [`SpacetimeDBClient.constructor`](#spacetimedbclient-constructor) | Creates a new `SpacetimeDBClient` database client.                       |
-| Properties                                                        |
-| [`SpacetimeDBClient.identity`](#spacetimedbclient-identity)       | The user's public identity.                                              |
-| [`SpacetimeDBClient.live`](#spacetimedbclient-live)               | Whether the client is connected.                                         |
-| [`SpacetimeDBClient.token`](#spacetimedbclient-token)             | The user's private authentication token.                                 |
-| Methods                                                           |                                                                          |
-| [`SpacetimeDBClient.connect`](#spacetimedbclient-connect)         | Connect to a SpacetimeDB module.                                         |
-| [`SpacetimeDBClient.disconnect`](#spacetimedbclient-disconnect)   | Close the current connection.                                            |
-| [`SpacetimeDBClient.subscribe`](#spacetimedbclient-subscribe)     | Subscribe to a set of queries.                                           |
-| Events                                                            |                                                                          |
-| [`SpacetimeDBClient.onConnect`](#spacetimedbclient-onconnect)     | Register a callback to be invoked upon authentication with the database. |
-| [`SpacetimeDBClient.onError`](#spacetimedbclient-onerror)         | Register a callback to be invoked upon a error.                          |
-
-## Constructors
-
-### `SpacetimeDBClient` constructor
-
-Creates a new `SpacetimeDBClient` database client and set the initial parameters.
-
-```ts
-new SpacetimeDBClient(host: string, name_or_address: string, auth_token?: string, protocol?: "binary" | "json")
+```typescript
+module_bindings.DbConnection
 ```
 
-#### Parameters
+A connection to a remote database is represented by the `module_bindings.DbConnection` type. This type is generated per-module, and contains information about the types, tables and reducers defined by your module.
 
-| Name              | Type                   | Description                                                                                                                                       |
-| :---------------- | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `host`            | `string`               | The host of the SpacetimeDB server.                                                                                                               |
-| `name_or_address` | `string`               | The name or address of the SpacetimeDB module.                                                                                                    |
-| `auth_token?`     | `string`               | The credentials to use to connect to authenticate with SpacetimeDB.                                                                               |
-| `protocol?`       | `"binary"` \| `"json"` | Define how encode the messages: `"binary"` \| `"json"`. Binary is more efficient and compact, but JSON provides human-readable debug information. |
+| Name                                                      | Description                                                                                      |
+|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| [Connect to a module](#connect-to-a-module)               | Construct a `DbConnection`.                                                                      |
+| [Access tables and reducers](#access-tables-and-reducers) | Access subscribed rows in the client cache, request reducer invocations, and register callbacks. |
 
-#### Example
 
-```ts
-const host = 'ws://localhost:3000';
-const name_or_address = 'database_name';
-const auth_token = undefined;
-const protocol = 'binary';
+### Connect to a module
 
-var spacetimeDBClient = new SpacetimeDBClient(
-  host,
-  name_or_address,
-  auth_token,
-  protocol
-);
+```typescript
+DbConnection.builder(): DbConnectionBuilder
 ```
 
-## Class methods
+Construct a `DbConnection` by calling `DbConnection.builder()` and chaining configuration methods, then calling `.build()`. You must at least specify `withUri`, to supply the URI of the SpacetimeDB to which you published your module, and `with_module_name`, to supply the human-readable SpacetimeDB domain name or the raw `Identity` which identifies the module.
 
-### `SpacetimeDBClient.registerReducers`
+| Name                                                  | Description                                                                          |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------|
+| [`withUri` method](#method-withuri)                   | Set the URI of the SpacetimeDB instance which hosts the remote database.             |
+| [`withModuleName` method](#method-withmodulename)     | Set the name or `Identity` of the remote database.                                   |
+| [`onConnect` callback](#callback-onconnect)           | Register a callback to run when the connection is successfully established.          |
+| [`onConnectError` callback](#callback-onconnecterror) | Register a callback to run if the connection is rejected or the host is unreachable. |
+| [`onDisconnect` callback](#callback-ondisconnect)     | Register a callback to run when the connection ends.                                 |
+| [`withToken` method](#method-withToken)               | Supply a token to authenticate with the remote database.                             |
+| [`build` method](#method-build)                       | Finalize configuration and connect.                                                  |
 
-Registers reducer classes for use with a SpacetimeDBClient
+#### Method `withUri`
 
-```ts
-registerReducers(...reducerClasses: ReducerClass[])
+```typescript
+DbConnectionBuilder.withUri(uri: string): DbConnectionBuilder
 ```
 
-#### Parameters
+Configure the URI of the SpacetimeDB instance or cluster which hosts the remote module.
 
-| Name             | Type           | Description                   |
-| :--------------- | :------------- | :---------------------------- |
-| `reducerClasses` | `ReducerClass` | A list of classes to register |
+#### Method `withModuleName`
 
-#### Example
-
-```ts
-import SayHelloReducer from './types/say_hello_reducer';
-import AddReducer from './types/add_reducer';
-
-SpacetimeDBClient.registerReducers(SayHelloReducer, AddReducer);
-```
-
----
-
-### `SpacetimeDBClient.registerTables`
-
-Registers table classes for use with a SpacetimeDBClient
-
-```ts
-registerTables(...reducerClasses: TableClass[])
-```
-
-#### Parameters
-
-| Name           | Type         | Description                   |
-| :------------- | :----------- | :---------------------------- |
-| `tableClasses` | `TableClass` | A list of classes to register |
-
-#### Example
-
-```ts
-import User from './types/user';
-import Player from './types/player';
-
-SpacetimeDBClient.registerTables(User, Player);
-```
-
----
-
-## Properties
-
-### `SpacetimeDBClient` identity
-
-The user's public [Identity](#class-identity).
+```typescript
+DbConnectionBuilder.withModuleName(name_or_identity: string): DbConnectionBuilder
 
 ```
-identity: Identity | undefined
+
+Configure the SpacetimeDB domain name or `Identity` of the remote module which identifies it within the SpacetimeDB instance or cluster.
+
+#### Callback `onConnect`
+
+```typescript
+DbConnectionBuilder.onConnect(
+    callback: (ctx: DbConnection, identity: Identity, token: string) => void
+): DbConnectionBuilder
 ```
 
----
+Chain a call to `.onConnect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote module. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`withToken`](#method-withToken) to authenticate the same user in future connections.
 
-### `SpacetimeDBClient` live
+This interface may change in an upcoming release as we rework SpacetimeDB's authentication model.
 
-Whether the client is connected.
+#### Callback `onConnectError`
 
-```ts
-live: boolean;
+```typescript
+DbConnectionBuilder.onConnectError(
+    callback: (ctx: ErrorContext, error: Error) => void
+): DbConnectionBuilder
 ```
 
----
+Chain a call to `.onConnectError(callback)` to your builder to register a callback to run when your connection fails.
 
-### `SpacetimeDBClient` token
+#### Callback `onDisconnect`
 
-The user's private authentication token.
+```typescript
+DbConnectionBuilder.onDisconnect(
+    callback: (ctx: ErrorContext, error: Error | null) => void
+): DbConnectionBuilder
 
 ```
-token: string | undefined
+
+Chain a call to `.onDisconnect(callback)` to your builder to register a callback to run when your `DbConnection` disconnects from the remote module, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error.
+
+#### Method `withToken`
+
+```typescript
+DbConnectionBuilder.withToken(token: string | null): DbConnectionBuilder
 ```
 
-#### Parameters
+Chain a call to `.withToken(token)` to your builder to provide an OpenID Connect compliant JSON Web Token to authenticate with, or to explicitly select an anonymous connection. If this method is not called or `null` is passed, SpacetimeDB will generate a new `Identity` and sign a new private access token for the connection.
 
-| Name          | Type         | Description                     |
-| :------------ | :----------- | :------------------------------ |
-| `reducerName` | `string`     | The name of the reducer to call |
-| `serializer`  | `Serializer` | -                               |
 
----
+#### Method `build`
 
-### `SpacetimeDBClient` connect
-
-Connect to The SpacetimeDB Websocket For Your Module. By default, this will use a secure websocket connection. The parameters are optional, and if not provided, will use the values provided on construction of the client.
-
-```ts
-connect(host: string?, name_or_address: string?, auth_token: string?): Promise<void>
+```typescript
+DbConnectionBuilder.build(): DbConnection
 ```
 
-#### Parameters
+After configuring the connection and registering callbacks, attempt to open the connection.
 
-| Name               | Type     | Description                                                                                                                                 |
-| :----------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
-| `host?`            | `string` | The hostname of the SpacetimeDB server. Defaults to the value passed to the [constructor](#spacetimedbclient-constructor).                  |
-| `name_or_address?` | `string` | The name or address of the SpacetimeDB module. Defaults to the value passed to the [constructor](#spacetimedbclient-constructor).           |
-| `auth_token?`      | `string` | The credentials to use to authenticate with SpacetimeDB. Defaults to the value passed to the [constructor](#spacetimedbclient-constructor). |
+### Access tables and reducers
 
-#### Returns
+#### Field `db`
 
-`Promise`<`void`\>
-
-#### Example
-
-```ts
-const host = 'ws://localhost:3000';
-const name_or_address = 'database_name';
-const auth_token = undefined;
-
-var spacetimeDBClient = new SpacetimeDBClient(
-  host,
-  name_or_address,
-  auth_token
-);
-// Connect with the initial parameters
-spacetimeDBClient.connect();
-//Set the `auth_token`
-spacetimeDBClient.connect(undefined, undefined, NEW_TOKEN);
+```rust
+DbConnection.db: RemoteTables
 ```
 
----
+The `db` field of the `DbConnection` provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
 
-### `SpacetimeDBClient` disconnect
+#### Field `reducers`
 
-Close the current connection.
-
-```ts
-disconnect(): void
+```rust
+DbConnection.reducers: RemoteReducers
 ```
 
-#### Example
+The `reducers` field of the `DbConnection` provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
 
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
+## Interface `DbContext`
 
-spacetimeDBClient.disconnect();
+```rust
+interface spacetimedb_sdk.DbContext<
+    DbView,
+    Reducers,
+>
 ```
 
----
+[`DbConnection`](#type-dbconnection), [`EventContext`](#type-eventcontext), [`ReducerEventContext`](#type-reducereventcontext), [`SubscriptionEventContext`](#type-subscriptioneventcontext) and [`ErrorContext`](#type-errorcontext) all implement `DbContext`. `DbContext` has fields and methods for inspecting and configuring your connection to the remote database.
 
-### `SpacetimeDBClient` subscribe
+The `DbContext` trait is implemented by connections and contexts to *every* module. This means that its [`DbView`](#field-db) and [`Reducers`](#field-reducers) are generic types.
 
-Subscribe to a set of queries, to be notified when rows which match those queries are altered.
+| Name                                                  | Description                                                              |
+|-------------------------------------------------------|--------------------------------------------------------------------------|
+| [`db` field](#field-db)                               | Access subscribed rows of tables and register row callbacks.             |
+| [`reducers` field](#field-reducers)                   | Request reducer invocations and register reducer callbacks.              |
+| [`disconnect` method](#method-disconnect)             | End the connection.                                                      |
+| [Subscribe to queries](#subscribe-to-queries)         | Register SQL queries to receive updates about matching rows.             |
+| [Read connection metadata](#read-connection-metadata) | Access the connection's `Identity` and `ConnectionId`                    |
 
-> A new call to `subscribe` will remove all previous subscriptions and replace them with the new `queries`.
-> If any rows matched the previous subscribed queries but do not match the new queries,
-> those rows will be removed from the client cache, and [`{Table}.on_delete`](#table-ondelete) callbacks will be invoked for them.
+#### Field `db`
 
-```ts
-subscribe(queryOrQueries: string | string[]): void
+```typescript
+DbConnection.db: DbView
 ```
 
-#### Parameters
+The `db` field of a `DbContext` provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
 
-| Name             | Type                   | Description                      |
-| :--------------- | :--------------------- | :------------------------------- |
-| `queryOrQueries` | `string` \| `string`[] | A `SQL` query or list of queries |
+#### Field `reducers`
 
-#### Example
-
-```ts
-spacetimeDBClient.subscribe(['SELECT * FROM User', 'SELECT * FROM Message']);
+```typescript
+DbConnection.reducers: Reducers
 ```
 
-## Events
+The `reducers` field of a `DbContext` provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
 
-### `SpacetimeDBClient` onConnect
+### Method `disconnect`
 
-Register a callback to be invoked upon authentication with the database.
-
-```ts
-onConnect(callback: (token: string, identity: Identity) => void): void
+```typescript
+DbContext.disconnect(): void
 ```
 
-The callback will be invoked with the public user [Identity](#class-identity), private authentication token and connection [`Address`](#class-address) provided by the database. If credentials were supplied to [connect](#spacetimedbclient-connect), those passed to the callback will be equivalent to the ones used to connect. If the initial connection was anonymous, a new set of credentials will be generated by the database to identify this user.
+Gracefully close the `DbConnection`. Throws an error if the connection is already disconnected.
 
-The credentials passed to the callback can be saved and used to authenticate the same user in future connections.
+### Subscribe to queries
 
-#### Parameters
+| Name                                                    | Description                                                 |
+|---------------------------------------------------------|-------------------------------------------------------------|
+| [`SubscriptionBuilder` type](#type-subscriptionbuilder) | Builder-pattern constructor to register subscribed queries. |
+| [`SubscriptionHandle` type](#type-subscriptionhandle)   | Manage an active subscripion.                               |
 
-| Name       | Type                                                                                                             |
-| :--------- | :--------------------------------------------------------------------------------------------------------------- |
-| `callback` | (`token`: `string`, `identity`: [`Identity`](#class-identity), `address`: [`Address`](#class-address)) => `void` |
+#### Type `SubscriptionBuilder`
 
-#### Example
-
-```ts
-spacetimeDBClient.onConnect((token, identity, address) => {
-  console.log('Connected to SpacetimeDB');
-  console.log('Token', token);
-  console.log('Identity', identity);
-  console.log('Address', address);
-});
+```typescript
+spacetimedb_sdk::SubscriptionBuilder
 ```
 
----
+| Name                                                                           | Description                                                     |
+|--------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| [`ctx.subscriptionBuilder()` constructor](#constructor-ctxsubscriptionbuilder) | Begin configuring a new subscription.                           |
+| [`onApplied` callback](#callback-onapplied)                                    | Register a callback to run when matching rows become available. |
+| [`onError` callback](#callback-onerror)                                        | Register a callback to run if the subscription fails.           |
+| [`subscribe` method](#method-subscribe)                                        | Finish configuration and subscribe to one or more SQL queries.  |
+| [`subscribeToAllTables` method](#method-subscribetoalltables)                  | Convenience method to subscribe to the entire database.         |
 
-### `SpacetimeDBClient` onError
+##### Constructor `ctx.subscriptionBuilder()`
 
-Register a callback to be invoked upon an error.
+```typescript
+DbContext.subscriptionBuilder(): SubscriptionBuilder
 
-```ts
-onError(callback: (...args: any[]) => void): void
 ```
 
-#### Parameters
+Subscribe to queries by calling `ctx.subscription_builder()` and chaining configuration methods, then calling `.subscribe(queries)`.
 
-| Name       | Type                           |
-| :--------- | :----------------------------- |
-| `callback` | (...`args`: `any`[]) => `void` |
+##### Callback `onApplied`
 
-#### Example
-
-```ts
-spacetimeDBClient.onError((...args: any[]) => {
-  console.error('ERROR', args);
-});
+```typescript
+SubscriptionBuilder.onApplied(
+    callback: (ctx: SubscriptionEventContext) => void
+): SubscriptionBuilder
 ```
 
-### Class `Identity`
+Register a callback to run when the subscription is applied and the matching rows are inserted into the client cache.
 
-A unique public identifier for a user of a database.
+##### Callback `onError`
 
-Defined in [spacetimedb-sdk.identity](https://github.com/clockworklabs/spacetimedb-typescript-sdk/blob/main/src/identity.ts):
+```typescript
+SubscriptionBuilder.onError(
+    callback: (ctx: ErrorContext, error: Error) => void
+): SubscriptionBuilder
 
-| Constructors                                    | Description                                  |
-| ----------------------------------------------- | -------------------------------------------- |
-| [`Identity.constructor`](#identity-constructor) | Creates a new `Identity`.                    |
-| Methods                                         |                                              |
-| [`Identity.isEqual`](#identity-isequal)         | Compare two identities for equality.         |
-| [`Identity.toHexString`](#identity-tohexstring) | Print the identity as a hexadecimal string.  |
-| Static methods                                  |                                              |
-| [`Identity.fromString`](#identity-fromstring)   | Parse an Identity from a hexadecimal string. |
-
-## Constructors
-
-### `Identity` constructor
-
-```ts
-new Identity(data: Uint8Array)
 ```
 
-#### Parameters
+Register a callback to run if the subscription is rejected or unexpectedly terminated by the server. This is most frequently caused by passing an invalid query to [`subscribe`](#method-subscribe).
 
-| Name   | Type         |
-| :----- | :----------- |
-| `data` | `Uint8Array` |
 
-## Methods
+##### Method `subscribe`
 
-### `Identity` isEqual
-
-Compare two identities for equality.
-
-```ts
-isEqual(other: Identity): boolean
+```typescript
+SubscriptionBuilder.subscribe(queries: string | string[]): SubscriptionHandle
 ```
 
-#### Parameters
+Subscribe to a set of queries.
 
-| Name    | Type                          |
-| :------ | :---------------------------- |
-| `other` | [`Identity`](#class-identity) |
+##### Method `subscribeToAllTables`
 
-#### Returns
-
-`boolean`
-
----
-
-### `Identity` toHexString
-
-Print an `Identity` as a hexadecimal string.
-
-```ts
-toHexString(): string
+```typescript
+SubscriptionBuilder.subscribe_to_all_tables(): void
 ```
 
-#### Returns
+Subscribe to all rows from all tables. This method is provided as a convenience for simple clients. The same connection must not mix `subscribeToAllTables` with [`subscribe` to specific queries](#method-subscribe). Doing so may cause errors or corrupt the client cache, leading to local queries returning incorrect results. The subscription initiated by `subscribeToAllTables` cannot be canceled after it is initiated.
 
-`string`
+#### Type `SubscriptionHandle`
 
----
-
-### `Identity` fromString
-
-Static method; parse an Identity from a hexadecimal string.
-
-```ts
-Identity.fromString(str: string): Identity
+```rust
+module_bindings::SubscriptionHandle
 ```
 
-#### Parameters
+A `SubscriptionHandle` represents a subscribed query or a group of subscribed queries.
 
-| Name  | Type     |
-| :---- | :------- |
-| `str` | `string` |
+The `SubscriptionHandle` does not contain or provide access to the subscribed rows. Subscribed rows of all subscriptions by a connection are contained within that connection's [`ctx.db`](#field-db). See [Access the client cache](#access-the-client-cache).
 
-#### Returns
+| Name                                                | Description                                                                                                      |
+|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| [`isEnded` method](#method-isended)                 | Determine whether the subscription has ended.                                                                    |
+| [`isActive` method](#method-isactive)               | Determine whether the subscription is active and its matching rows are present in the client cache.              |
+| [`unsubscribe` method](#method-unsubscribe)         | Discard a subscription.                                                                                          |
+| [`unsubscribeThen` method](#method-unsubscribethen) | Discard a subscription, and register a callback to run when its matching rows are removed from the client cache. |
 
-[`Identity`](#class-identity)
+##### Method `is_ended`
 
-### Class `Address`
-
-An opaque identifier for a client connection to a database, intended to differentiate between connections from the same [`Identity`](#class-identity).
-
-Defined in [spacetimedb-sdk.address](https://github.com/clockworklabs/spacetimedb-typescript-sdk/blob/main/src/address.ts):
-
-| Constructors                                  | Description                                 |
-| --------------------------------------------- | ------------------------------------------- |
-| [`Address.constructor`](#address-constructor) | Creates a new `Address`.                    |
-| Methods                                       |                                             |
-| [`Address.isEqual`](#address-isequal)         | Compare two identities for equality.        |
-| [`Address.toHexString`](#address-tohexstring) | Print the address as a hexadecimal string.  |
-| Static methods                                |                                             |
-| [`Address.fromString`](#address-fromstring)   | Parse an Address from a hexadecimal string. |
-
-## Constructors
-
-### `Address` constructor
-
-```ts
-new Address(data: Uint8Array)
+```typescript
+SubscriptionHandle.is_ended(): bool
 ```
 
-#### Parameters
+Returns true if this subscription has been terminated due to an unsubscribe call or an error.
 
-| Name   | Type         |
-| :----- | :----------- |
-| `data` | `Uint8Array` |
+##### Method `isActive`
 
-## Methods
-
-### `Address` isEqual
-
-Compare two addresses for equality.
-
-```ts
-isEqual(other: Address): boolean
+```typescript
+SubscriptionHandle.isActive(): bool
 ```
 
-#### Parameters
+Returns true if this subscription has been applied and has not yet been unsubscribed.
 
-| Name    | Type                        |
-| :------ | :-------------------------- |
-| `other` | [`Address`](#class-address) |
+##### Method `unsubscribe`
 
-#### Returns
-
-`boolean`
-
----
-
-### `Address` toHexString
-
-Print an `Address` as a hexadecimal string.
-
-```ts
-toHexString(): string
+```typescript
+SubscriptionHandle.unsubscribe(): void
 ```
 
-#### Returns
+Terminate this subscription, causing matching rows to be removed from the client cache. Any rows removed from the client cache this way will have [`onDelete` callbacks](#callback-ondelete) run for them.
 
-`string`
+Unsubscribing is an asynchronous operation. Matching rows are not removed from the client cache immediately. Use [`unsubscribeThen`](#method-unsubscribethen) to run a callback once the unsubscribe operation is completed.
 
----
+Throws an error if the subscription has already ended, either due to a previous call to `unsubscribe` or [`unsubscribeThen`](#method-unsubscribethen), or due to an error.
 
-### `Address` fromString
+##### Method `unsubscribeTthen`
 
-Static method; parse an Address from a hexadecimal string.
+```typescript
+SubscriptionHandle.unsubscribe_then(
+    on_end: (ctx: SubscriptionEventContext) => void
+): void
 
-```ts
-Address.fromString(str: string): Address
 ```
 
-#### Parameters
+Terminate this subscription, and run the `onEnd` callback when the subscription is ended and its matching rows are removed from the client cache. Any rows removed from the client cache this way will have [`onDelete` callbacks](#callback-ondelete) run for them.
 
-| Name  | Type     |
-| :---- | :------- |
-| `str` | `string` |
+Returns an error if the subscription has already ended, either due to a previous call to [`unsubscribe`](#method-unsubscribe) or `unsubscribe_then`, or due to an error.
 
-#### Returns
+### Read connection metadata
 
-[`Address`](#class-address)
+#### Field `isActive`
 
-### Class `{Table}`
-
-For each table defined by a module, `spacetime generate` generates a `class` in the `module_bindings` folder whose name is that table's name converted to `PascalCase`.
-
-The generated class has a field for each of the table's columns, whose names are the column names converted to `snake_case`.
-
-| Properties                                        | Description                                                                                                                             |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| [`Table.name`](#table-name)                       | The name of the class.                                                                                                                  |
-| [`Table.tableName`](#table-tablename)             | The name of the table in the database.                                                                                                  |
-| Methods                                           |                                                                                                                                         |
-| [`Table.all`](#table-all)                         | Return all the subscribed rows in the table.                                                                                            |
-| [`Table.filterBy{COLUMN}`](#table-filterbycolumn) | Autogenerated; return subscribed rows with a given value in a particular column. `{COLUMN}` is a placeholder for a column name.         |
-| [`Table.findBy{COLUMN}`](#table-findbycolumn)     | Autogenerated; return a subscribed row with a given value in a particular unique column. `{COLUMN}` is a placeholder for a column name. |
-| Events                                            |                                                                                                                                         |
-| [`Table.onInsert`](#table-oninsert)               | Register an `onInsert` callback for when a subscribed row is newly inserted into the database.                                          |
-| [`Table.removeOnInsert`](#table-removeoninsert)   | Unregister a previously-registered [`onInsert`](#table-oninsert) callback.                                                              |
-| [`Table.onUpdate`](#table-onupdate)               | Register an `onUpdate` callback for when an existing row is modified.                                                                   |
-| [`Table.removeOnUpdate`](#table-removeonupdate)   | Unregister a previously-registered [`onUpdate`](#table-onupdate) callback.                                                              |
-| [`Table.onDelete`](#table-ondelete)               | Register an `onDelete` callback for when a subscribed row is removed from the database.                                                 |
-| [`Table.removeOnDelete`](#table-removeondelete)   | Unregister a previously-registered [`onDelete`](#table-removeondelete) callback.                                                        |
-
-## Properties
-
-### {Table} name
-
-• **name**: `string`
-
-The name of the `Class`.
-
----
-
-### {Table} tableName
-
-The name of the table in the database.
-
-▪ `Static` **tableName**: `string` = `"Person"`
-
-## Methods
-
-### {Table} all
-
-Return all the subscribed rows in the table.
-
-```ts
-{Table}.all(): {Table}[]
+```typescript
+DbContext.isActive: bool
 ```
 
-#### Returns
+`true` if the connection has not yet disconnected. Note that a connection `isActive` when it is constructed, before its [`onConnect` callback](#callback-onconnect) is invoked.
 
-`{Table}[]`
+## Type `EventContext`
 
-#### Example
-
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-
-  setTimeout(() => {
-    console.log(Person.all()); // Prints all the `Person` rows in the database.
-  }, 5000);
-});
+```typescript
+module_bindings.EventContext
 ```
 
----
+An `EventContext` is a [`DbContext`](#interface-dbcontext) augmented with a field [`event: Event`](#type-event). `EventContext`s are passed as the first argument to row callbacks [`onInsert`](#callback-oninsert), [`onDelete`](#callback-ondelete) and [`onUpdate`](#callback-onupdate).
 
-### {Table} count
+| Name                                | Description                                                   |
+|-------------------------------------|---------------------------------------------------------------|
+| [`event` field](#field-event)       | Enum describing the cause of the current row callback.        |
+| [`db` field](#field-db)             | Provides access to the client cache.                          |
+| [`reducers` field](#field-reducers) | Allows requesting reducers run on the remote database.        |
+| [`Event` type](#type-event)         | Possible events which can cause a row callback to be invoked. |
 
-Return the number of subscribed rows in the table, or 0 if there is no active connection.
+### Field `event`
 
-```ts
-{Table}.count(): number
+```typescript
+EventContext.event: spacetimedb_sdk.Event<module_bindings.Reducer>,
+/* other fields */
+
 ```
 
-#### Returns
+The [`Event`](#enum-event) contained in the `EventContext` describes what happened to cause the current row callback to be invoked.
 
-`number`
+### Field `db`
 
-#### Example
-
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-
-  setTimeout(() => {
-    console.log(Person.count());
-  }, 5000);
-});
+```rust
+EventContext.db: RemoteTables
 ```
 
----
+The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
 
-### {Table} filterBy{COLUMN}
+### Field `reducers`
 
-For each column of a table, `spacetime generate` generates a static method on the `Class` to filter subscribed rows where that column matches a requested value.
-
-These methods are named `filterBy{COLUMN}`, where `{COLUMN}` is the column name converted to `camelCase`.
-
-```ts
-{Table}.filterBy{COLUMN}(value): Iterable<{Table}>
+```rust
+EventContext.reducers: RemoteReducers
 ```
 
-#### Parameters
+The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
 
-| Name    | Type                        |
-| :------ | :-------------------------- |
-| `value` | The type of the `{COLUMN}`. |
+### Type `Event`
 
-#### Returns
-
-`Iterable<{Table}>`
-
-#### Example
-
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-
-  setTimeout(() => {
-    console.log(...Person.filterByName('John')); // prints all the `Person` rows named John.
-  }, 5000);
-});
+```rust
+type spacetimedb_sdk.Event<Reducer> =
+  | { tag: 'Reducer'; value: ReducerEvent<Reducer> }
+  | { tag: 'SubscribeApplied' }
+  | { tag: 'UnsubscribeApplied' }
+  | { tag: 'Error'; value: Error }
+  | { tag: 'UnknownTransaction' };
 ```
 
----
+| Name                                                        | Description                                                                                                                             |
+|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| [`Reducer` variant](#variant-reducer)                       | A reducer ran in the remote database.                                                                                                   |
+| [`SubscribeApplied` variant](#variant-subscribeapplied)     | A new subscription was applied to the client cache.                                                                                     |
+| [`UnsubscribeApplied` variant](#variant-unsubscribeapplied) | A previous subscription was removed from the client cache after a call to [`unsubscribe`](#method-unsubscribe).                         |
+| [`Error` variant](#variant-error)                           | A previous subscription was removed from the client cache due to an error.                                                              |
+| [`UnknownTransaction` variant](#variant-unknowntransaction) | A transaction ran in the remote database, but was not attributed to a known reducer.                                                    |
+| [`ReducerEvent` type](#type-reducerevent)                   | Metadata about a reducer run. Contained in [`Event::Reducer`](#variant-reducer) and [`ReducerEventContext`](#type-reducereventcontext). |
+| [`UpdateStatus` type](#type-updatestatus)                   | Completion status of a reducer run.                                                                                                     |
+| [`Reducer` type](#type-reducer)                             | Module-specific generated enum with a variant for each reducer defined by the module.                                                   |
 
-### {Table} findBy{COLUMN}
+#### Variant `Reducer`
 
-For each unique column of a table, `spacetime generate` generates a static method on the `Class` to find the subscribed row where that column matches a requested value.
-
-These methods are named `findBy{COLUMN}`, where `{COLUMN}` is the column name converted to `camelCase`.
-
-```ts
-{Table}.findBy{COLUMN}(value): {Table} | undefined
+```typescript
+{ tag: 'Reducer'; value: spacetimedb_sdk.ReducerEvent<Reducer> }
 ```
 
-#### Parameters
+Event when we are notified that a reducer ran in the remote module. The [`ReducerEvent`](#type-reducerevent) contains metadata about the reducer run, including its arguments and termination status(#type-updatestatus).
 
-| Name    | Type                        |
-| :------ | :-------------------------- |
-| `value` | The type of the `{COLUMN}`. |
+This event is passed to row callbacks resulting from modifications by the reducer.
 
-#### Returns
+#### Variant `SubscribeApplied`
 
-`{Table} | undefined`
-
-#### Example
-
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-
-  setTimeout(() => {
-    console.log(Person.findById(0)); // prints a `Person` row with id 0.
-  }, 5000);
-});
+```typescript
+{ tag: 'SubscribeApplied' }
 ```
 
----
+Event when our subscription is applied and its rows are inserted into the client cache.
 
-### {Table} fromValue
+This event is passed to [row `onInsert` callbacks](#callback-oninsert) resulting from the new subscription.
 
-Deserialize an `AlgebraicType` into this `{Table}`.
+#### Variant `UnsubscribeApplied`
 
-```ts
- {Table}.fromValue(value: AlgebraicValue): {Table}
+```typescript
+{ tag: 'UnsubscribeApplied' }
 ```
 
-#### Parameters
+Event when our subscription is removed after a call to [`SubscriptionHandle.unsubscribe`](#method-unsubscribe) or [`SubscriptionHandle.unsubscribeThen`](#method-unsubscribethen) and its matching rows are deleted from the client cache.
 
-| Name    | Type             |
-| :------ | :--------------- |
-| `value` | `AlgebraicValue` |
+This event is passed to [row `onDelete` callbacks](#callback-ondelete) resulting from the subscription ending.
 
-#### Returns
+#### Variant `SubscribeError`
 
-`{Table}`
+```typescript
+{ tag: 'Error'; value: Error }
 
----
-
-### {Table} getAlgebraicType
-
-Serialize `this` into an `AlgebraicType`.
-
-#### Example
-
-```ts
-{Table}.getAlgebraicType(): AlgebraicType
 ```
 
-#### Returns
+Event when a subscription ends unexpectedly due to an error.
 
-`AlgebraicType`
+This event is passed to [row `onDelete` callbacks](#callback-ondelete) resulting from the subscription ending.
 
----
+#### Variant `UnknownTransaction`
 
-### {Table} onInsert
-
-Register an `onInsert` callback for when a subscribed row is newly inserted into the database.
-
-```ts
-{Table}.onInsert(callback: (value: {Table}, reducerEvent: ReducerEvent | undefined) => void): void
+```typescript
+{ tag: 'UnknownTransaction' }
 ```
 
-#### Parameters
+Event when we are notified of a transaction in the remote module which we cannot associate with a known reducer. This may be an ad-hoc SQL query or a reducer for which we do not have bindings.
 
-| Name       | Type                                                                          | Description                                            |
-| :--------- | :---------------------------------------------------------------------------- | :----------------------------------------------------- |
-| `callback` | (`value`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` | Callback to run whenever a subscribed row is inserted. |
+This event is passed to [row callbacks](#callback-oninsert) resulting from modifications by the transaction.
 
-#### Example
+### Type `ReducerEvent`
 
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-});
+A `ReducerEvent` contains metadata about a reducer run.
 
-Person.onInsert((person, reducerEvent) => {
-  if (reducerEvent) {
-    console.log('New person inserted by reducer', reducerEvent, person);
-  } else {
-    console.log('New person received during subscription update', person);
-  }
-});
+```typescript
+type spacetimedb_sdk.ReducerEvent<Reducer> = {
+  /**
+   * The time when the reducer started running.
+   */
+  timestamp: Timestamp;
+
+  /**
+   * Whether the reducer committed, was aborted due to insufficient energy, or failed with an error message.
+   */
+  status: UpdateStatus;
+
+  /**
+   * The identity of the caller.
+   * TODO: Revise these to reflect the forthcoming Identity proposal.
+   */
+  callerIdentity: Identity;
+
+  /**
+   * The connection ID of the caller.
+   *
+   * May be `null`, e.g. for scheduled reducers.
+   */
+  callerConnectionId?: ConnectionId;
+
+  /**
+   * The amount of energy consumed by the reducer run, in eV.
+   * (Not literal eV, but our SpacetimeDB energy unit eV.)
+   * May be present or undefined at the implementor's discretion;
+   * future work may determine an interface for module developers
+   * to request this value be published or hidden.
+   */
+  energyConsumed?: bigint;
+
+  /**
+   * The `Reducer` enum defined by the `module_bindings`, which encodes which reducer ran and its arguments.
+   */
+  reducer: Reducer;
+};
 ```
 
----
+### Type `UpdateStatus`
 
-### {Table} removeOnInsert
-
-Unregister a previously-registered [`onInsert`](#table-oninsert) callback.
-
-```ts
-{Table}.removeOnInsert(callback: (value: Person, reducerEvent: ReducerEvent | undefined) => void): void
+```typescript
+type spacetimedb_sdk.UpdateStatus =
+  | { tag: 'Committed'; value: __DatabaseUpdate }
+  | { tag: 'Failed'; value: string }
+  | { tag: 'OutOfEnergy' };
 ```
 
-#### Parameters
+| Name                                          | Description                                         |
+|-----------------------------------------------|-----------------------------------------------------|
+| [`Committed` variant](#variant-committed)     | The reducer ran successfully.                       |
+| [`Failed` variant](#variant-failed)           | The reducer errored.                                |
+| [`OutOfEnergy` variant](#variant-outofenergy) | The reducer was aborted due to insufficient energy. |
 
-| Name       | Type                                                                          |
-| :--------- | :---------------------------------------------------------------------------- |
-| `callback` | (`value`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` |
+#### Variant `Committed`
 
----
-
-### {Table} onUpdate
-
-Register an `onUpdate` callback to run when an existing row is modified by primary key.
-
-```ts
-{Table}.onUpdate(callback: (oldValue: {Table}, newValue: {Table}, reducerEvent: ReducerEvent | undefined) => void): void
+```typescript
+{ tag: 'Committed' }
 ```
 
-`onUpdate` callbacks are only meaningful for tables with a column declared as a primary key. Tables without primary keys will never fire `onUpdate` callbacks.
+The reducer returned successfully and its changes were committed into the database state. An [`Event` with `tag: 'Reducer'`](#variant-reducer) passed to a row callback must have this status in its [`ReducerEvent`](#struct-reducerevent).
 
-#### Parameters
+#### Variant `Failed`
 
-| Name       | Type                                                                                                    | Description                                           |
-| :--------- | :------------------------------------------------------------------------------------------------------ | :---------------------------------------------------- |
-| `callback` | (`oldValue`: `{Table}`, `newValue`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` | Callback to run whenever a subscribed row is updated. |
-
-#### Example
-
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-});
-
-Person.onUpdate((oldPerson, newPerson, reducerEvent) => {
-  console.log('Person updated by reducer', reducerEvent, oldPerson, newPerson);
-});
+```typescript
+{ tag: 'Failed'; value: string }
 ```
 
----
+The reducer returned an error, panicked, or threw an exception. The `value` is the stringified error message. Formatting of the error message is unstable and subject to change, so clients should use it only as a human-readable diagnostic, and in particular should not attempt to parse the message.
 
-### {Table} removeOnUpdate
+#### Variant `OutOfEnergy`
 
-Unregister a previously-registered [`onUpdate`](#table-onupdate) callback.
-
-```ts
-{Table}.removeOnUpdate(callback: (oldValue: {Table}, newValue: {Table}, reducerEvent: ReducerEvent | undefined) => void): void
+```typescript
+{ tag: 'OutOfEnergy' }
 ```
 
-#### Parameters
+The reducer was aborted due to insufficient energy balance of the module owner.
 
-| Name       | Type                                                                                                    |
-| :--------- | :------------------------------------------------------------------------------------------------------ |
-| `callback` | (`oldValue`: `{Table}`, `newValue`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` |
+### Type `Reducer`
 
----
-
-### {Table} onDelete
-
-Register an `onDelete` callback for when a subscribed row is removed from the database.
-
-```ts
-{Table}.onDelete(callback: (value: {Table}, reducerEvent: ReducerEvent | undefined) => void): void
+```rust
+type module_bindings.Reducer =
+  | { name: 'ReducerA'; args: ReducerA }
+  | { name: 'ReducerB'; args: ReducerB }
 ```
 
-#### Parameters
+The module bindings contains a type `Reducer` with a variant for each reducer defined by the module. Each variant has a field `args` containing the arguments to the reducer.
 
-| Name       | Type                                                                          | Description                                           |
-| :--------- | :---------------------------------------------------------------------------- | :---------------------------------------------------- |
-| `callback` | (`value`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` | Callback to run whenever a subscribed row is removed. |
+## Type `ReducerEventContext`
 
-#### Example
+A `ReducerEventContext` is a [`DbContext`](#trait-dbcontext) augmented with a field [`event: ReducerEvent`](#struct-reducerevent). `ReducerEventContext`s are passed as the first argument to [reducer callbacks](#observe-and-invoke-reducers).
 
-```ts
-var spacetimeDBClient = new SpacetimeDBClient(
-  'ws://localhost:3000',
-  'database_name'
-);
-spacetimeDBClient.onConnect((token, identity, address) => {
-  spacetimeDBClient.subscribe(['SELECT * FROM Person']);
-});
-
-Person.onDelete((person, reducerEvent) => {
-  if (reducerEvent) {
-    console.log('Person deleted by reducer', reducerEvent, person);
-  } else {
-    console.log(
-      'Person no longer subscribed during subscription update',
-      person
-    );
-  }
-});
-```
-
----
-
-### {Table} removeOnDelete
-
-Unregister a previously-registered [`onDelete`](#table-ondelete) callback.
-
-```ts
-{Table}.removeOnDelete(callback: (value: {Table}, reducerEvent: ReducerEvent | undefined) => void): void
-```
-
-#### Parameters
-
-| Name       | Type                                                                          |
-| :--------- | :---------------------------------------------------------------------------- |
-| `callback` | (`value`: `{Table}`, `reducerEvent`: `undefined` \| `ReducerEvent`) => `void` |
-
-### Class `{Reducer}`
-
-`spacetime generate` defines an `{Reducer}` class in the `module_bindings` folder for each reducer defined by a module.
-
-The class's name will be the reducer's name converted to `PascalCase`.
-
-| Static methods                  | Description                                                  |
-| ------------------------------- | ------------------------------------------------------------ |
-| [`Reducer.call`](#reducer-call) | Executes the reducer.                                        |
-| Events                          |                                                              |
-| [`Reducer.on`](#reducer-on)     | Register a callback to run each time the reducer is invoked. |
-
-## Static methods
-
-### {Reducer} call
-
-Executes the reducer.
-
-```ts
-{Reducer}.call(): void
-```
-
-#### Example
-
-```ts
-SayHelloReducer.call();
-```
-
-## Events
-
-### {Reducer} on
-
-Register a callback to run each time the reducer is invoked.
-
-```ts
-{Reducer}.on(callback: (reducerEvent: ReducerEvent, ...reducerArgs: any[]) => void): void
-```
-
-Clients will only be notified of reducer runs if either of two criteria is met:
-
-- The reducer inserted, deleted or updated at least one row to which the client is subscribed.
-- The reducer invocation was requested by this client, and the run failed.
-
-#### Parameters
-
-| Name       | Type                                                           |
-| :--------- | :------------------------------------------------------------- |
-| `callback` | `(reducerEvent: ReducerEvent, ...reducerArgs: any[]) => void)` |
-
-#### Example
-
-```ts
-SayHelloReducer.on((reducerEvent, ...reducerArgs) => {
-  console.log('SayHelloReducer called', reducerEvent, reducerArgs);
-});
-```
+| Name                                | Description                                                       |
+|-------------------------------------|-------------------------------------------------------------------|
+| [`event` field](#field-event)       | [`ReducerEvent`](#type-reducerevent) containing reducer metadata. |
+| [`db` field](#field-db)             | Provides access to the client cache.                              |
+| [`reducers` field](#field-reducers) | Allows requesting reducers run on the remote database.            |

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -308,7 +308,7 @@ See [the SpacetimeDB SQL Reference](/docs/sql#subscriptions) for information on 
 SubscriptionBuilder.subscribeToAllTables(): void
 ```
 
-Subscribe to all rows from all tables. This method is provided as a convenience for simple clients. The same connection must not mix `subscribeToAllTables` with [`subscribe` to specific queries](#method-subscribe). Doing so may cause errors or corrupt the client cache, leading to local queries returning incorrect results. The subscription initiated by `subscribeToAllTables` cannot be canceled after it is initiated.
+Subscribe to all rows from all public tables. This method is provided as a convenience for simple clients. The subscription initiated by `subscribeToAllTables ` cannot be canceled after it is initiated. You should [`subscribe` to specific queries](#method-subscribe) if you need fine-grained control over the lifecycle of your subscriptions.
 
 #### Type `SubscriptionHandle`
 

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -7,13 +7,13 @@ The SpacetimeDB client SDK for TypeScript contains all the tools you need to bui
 | [Project setup](#project-setup)                                   | Configure a Rust crate to use the SpacetimeDB Rust client SDK.                                                                         |
 | [Generate module bindings](#generate-module-bindings)             | Use the SpacetimeDB CLI to generate module-specific types and interfaces.                                                              |
 | [`DbConnection` type](#type-dbconnection)                         | A connection to a remote database.                                                                                                     |
-| [`DbContext` trait](#trait-dbcontext)                             | Methods for interacting with the remote database. Implemented by [`DbConnection`](#type-dbconnection) and various event context types. |
-| [`EventContext` type](#type-eventcontext)                         | [`DbContext`](#trait-dbcontext) available in [row callbacks](#callback-on_insert).                                                     |
-| [`ReducerEventContext` type](#type-reducereventcontext)           | [`DbContext`](#trait-dbcontext) available in [reducer callbacks](#observe-and-invoke-reducers).                                        |
-| [`SubscriptionEventContext` type](#type-subscriptioneventcontext) | [`DbContext`](#trait-dbcontext) available in [subscription-related callbacks](#subscribe-to-queries).                                  |
-| [`ErrorContext` type](#type-errorcontext)                         | [`DbContext`](#trait-dbcontext) available in error-related callbacks.                                                                  |
-| [Access the client cache](#access-the-client-cache)               | Make local queries against subscribed rows, and register [row callbacks](#callback-on_insert) to run when subscribed rows change.      |
-| [Observe and invoke reducers](#observe-and-invoke-reducers)       | Send requests to the database to run reducers, and register callbacks to run when notified of reducers.      |
+| [`DbContext` interface](#interface-dbcontext)                     | Methods for interacting with the remote database. Implemented by [`DbConnection`](#type-dbconnection) and various event context types. |
+| [`EventContext` type](#type-eventcontext)                         | [`DbContext`](#interface-dbcontext) available in [row callbacks](#callback-oninsert).                                                 |
+| [`ReducerEventContext` type](#type-reducereventcontext)           | [`DbContext`](#interface-dbcontext) available in [reducer callbacks](#observe-and-invoke-reducers).                                    |
+| [`SubscriptionEventContext` type](#type-subscriptioneventcontext) | [`DbContext`](#interface-dbcontext) available in [subscription-related callbacks](#subscribe-to-queries).                              |
+| [`ErrorContext` type](#type-errorcontext)                         | [`DbContext`](#interface-dbcontext) available in error-related callbacks.                                                              |
+| [Access the client cache](#access-the-client-cache)               | Make local queries against subscribed rows, and register [row callbacks](#callback-oninsert) to run when subscribed rows change.      |
+| [Observe and invoke reducers](#observe-and-invoke-reducers)       | Send requests to the database to run reducers, and register callbacks to run when notified of reducers.                                |
 | [Identify a client](#identify-a-client)                           | Types for identifying users and client connections.                                                                                    |
 
 ## Project setup
@@ -107,7 +107,7 @@ Construct a `DbConnection` by calling `DbConnection.builder()` and chaining conf
 | [`onConnect` callback](#callback-onconnect)           | Register a callback to run when the connection is successfully established.          |
 | [`onConnectError` callback](#callback-onconnecterror) | Register a callback to run if the connection is rejected or the host is unreachable. |
 | [`onDisconnect` callback](#callback-ondisconnect)     | Register a callback to run when the connection ends.                                 |
-| [`withToken` method](#method-withToken)               | Supply a token to authenticate with the remote database.                             |
+| [`withToken` method](#method-withtoken)               | Supply a token to authenticate with the remote database.                             |
 | [`build` method](#method-build)                       | Finalize configuration and connect.                                                  |
 
 #### Method `withUri`
@@ -135,7 +135,7 @@ DbConnectionBuilder.onConnect(
 ): DbConnectionBuilder
 ```
 
-Chain a call to `.onConnect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote module. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`withToken`](#method-withToken) to authenticate the same user in future connections.
+Chain a call to `.onConnect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote module. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`withToken`](#method-withtoken) to authenticate the same user in future connections.
 
 This interface may change in an upcoming release as we rework SpacetimeDB's authentication model.
 
@@ -206,7 +206,7 @@ interface spacetimedb_sdk.DbContext<
 
 [`DbConnection`](#type-dbconnection), [`EventContext`](#type-eventcontext), [`ReducerEventContext`](#type-reducereventcontext), [`SubscriptionEventContext`](#type-subscriptioneventcontext) and [`ErrorContext`](#type-errorcontext) all implement `DbContext`. `DbContext` has fields and methods for inspecting and configuring your connection to the remote database.
 
-The `DbContext` trait is implemented by connections and contexts to *every* module. This means that its [`DbView`](#field-db) and [`Reducers`](#field-reducers) are generic types.
+The `DbContext` interface is implemented by connections and contexts to *every* module. This means that its [`DbView`](#field-db) and [`Reducers`](#field-reducers) are generic types.
 
 | Name                                                  | Description                                                              |
 |-------------------------------------------------------|--------------------------------------------------------------------------|
@@ -327,10 +327,10 @@ The `SubscriptionHandle` does not contain or provide access to the subscribed ro
 | [`unsubscribe` method](#method-unsubscribe)         | Discard a subscription.                                                                                          |
 | [`unsubscribeThen` method](#method-unsubscribethen) | Discard a subscription, and register a callback to run when its matching rows are removed from the client cache. |
 
-##### Method `is_ended`
+##### Method `isEnded`
 
 ```typescript
-SubscriptionHandle.is_ended(): bool
+SubscriptionHandle.isEnded(): bool
 ```
 
 Returns true if this subscription has been terminated due to an unsubscribe call or an error.
@@ -355,7 +355,7 @@ Unsubscribing is an asynchronous operation. Matching rows are not removed from t
 
 Throws an error if the subscription has already ended, either due to a previous call to `unsubscribe` or [`unsubscribeThen`](#method-unsubscribethen), or due to an error.
 
-##### Method `unsubscribeTthen`
+##### Method `unsubscribeThen`
 
 ```typescript
 SubscriptionHandle.unsubscribe_then(
@@ -401,7 +401,7 @@ EventContext.event: spacetimedb_sdk.Event<module_bindings.Reducer>,
 
 ```
 
-The [`Event`](#enum-event) contained in the `EventContext` describes what happened to cause the current row callback to be invoked.
+The [`Event`](#type-event) contained in the `EventContext` describes what happened to cause the current row callback to be invoked.
 
 ### Field `db`
 
@@ -471,7 +471,7 @@ Event when our subscription is removed after a call to [`SubscriptionHandle.unsu
 
 This event is passed to [row `onDelete` callbacks](#callback-ondelete) resulting from the subscription ending.
 
-#### Variant `SubscribeError`
+#### Variant `Error`
 
 ```typescript
 { tag: 'Error'; value: Error }
@@ -558,7 +558,7 @@ type spacetimedb_sdk.UpdateStatus =
 { tag: 'Committed' }
 ```
 
-The reducer returned successfully and its changes were committed into the database state. An [`Event` with `tag: 'Reducer'`](#variant-reducer) passed to a row callback must have this status in its [`ReducerEvent`](#struct-reducerevent).
+The reducer returned successfully and its changes were committed into the database state. An [`Event` with `tag: 'Reducer'`](#variant-reducer) passed to a row callback must have this status in its [`ReducerEvent`](#type-reducerevent).
 
 #### Variant `Failed`
 
@@ -588,10 +588,219 @@ The module bindings contains a type `Reducer` with a variant for each reducer de
 
 ## Type `ReducerEventContext`
 
-A `ReducerEventContext` is a [`DbContext`](#trait-dbcontext) augmented with a field [`event: ReducerEvent`](#struct-reducerevent). `ReducerEventContext`s are passed as the first argument to [reducer callbacks](#observe-and-invoke-reducers).
+A `ReducerEventContext` is a [`DbContext`](#interface-dbcontext) augmented with a field [`event: ReducerEvent`](#type-reducerevent). `ReducerEventContext`s are passed as the first argument to [reducer callbacks](#observe-and-invoke-reducers).
 
 | Name                                | Description                                                       |
 |-------------------------------------|-------------------------------------------------------------------|
 | [`event` field](#field-event)       | [`ReducerEvent`](#type-reducerevent) containing reducer metadata. |
 | [`db` field](#field-db)             | Provides access to the client cache.                              |
 | [`reducers` field](#field-reducers) | Allows requesting reducers run on the remote database.            |
+
+### Field `event`
+
+```typescript
+ReducerEventContext.event: spacetimedb_sdk.ReducerEvent<module_bindings.Reducer>,
+```
+
+The [`ReducerEvent`](#type-reducerevent) contained in the `ReducerEventContext` has metadata about the reducer which ran.
+
+### Field `db`
+
+```typescript
+ReducerEventContext.db: RemoteTables
+```
+
+The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
+
+### Field `reducers`
+
+```typescript
+ReducerEventContext.reducers: RemoteReducers
+```
+
+The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
+
+## Type `SubscriptionEventContext`
+
+A `SubscriptionEventContext` is a [`DbContext`](#interface-dbcontext). Unlike the other context types, `SubscriptionEventContext` doesn't have an `event` field. `SubscriptionEventContext`s are passed to subscription [`onApplied`](#callback-onapplied) and [`unsubscribeThen`](#method-unsubscribethen) callbacks.
+
+| Name                                | Description                                                |
+|-------------------------------------|------------------------------------------------------------|
+| [`db` field](#field-db)             | Provides access to the client cache.                       |
+| [`reducers` field](#field-reducers) | Allows requesting reducers run on the remote database.     |
+
+### Field `db`
+
+```typescript
+SubscriptionEventContext.db: RemoteTables
+```
+
+The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
+
+### Field `reducers`
+
+```typescript
+SubscriptionEventContext.reducers: RemoteReducers
+```
+
+The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
+
+## Type `ErrorContext`
+
+An `ErrorContext` is a [`DbContext`](#interface-dbcontext) augmented with a field `event: Error`. `ErrorContext`s are to connections' [`onDisconnect`](#callback-ondisconnect) and [`onConnectError`](#callback-onconnecterror) callbacks, and to subscriptions' [`onError`](#callback-onerror) callbacks.
+
+| Name                                | Description                                            |
+|-------------------------------------|--------------------------------------------------------|
+| [`event` field](#field-event)       | The error which caused the current error callback.     |
+| [`db` field](#field-db)             | Provides access to the client cache.                   |
+| [`reducers` field](#field-reducers) | Allows requesting reducers run on the remote database. |
+
+
+### Field `event`
+
+```typescript
+ErrorContext.event: Error
+```
+
+### Field `db`
+
+```typescript
+ErrorContext.db: RemoteTables
+```
+
+The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
+
+### Field `reducers`
+
+```typescript
+ErrorContext.reducers: RemoteReducers
+```
+
+The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
+
+## Access the client cache
+
+All [`DbContext`](#interface-dbcontext) implementors, including [`DbConnection`](#type-dbconnection) and [`EventContext`](#type-eventcontext), have fields `.db`, which in turn has methods for accessing tables in the client cache.
+
+Each table defined by a module has an accessor method, whose name is the table name converted to `camelCase`, on this `.db` field. The table accessor methods return table handles. Table handles have methods for [accessing rows](#accessing-rows) and [registering `onInsert`](#callback-oninsert) and [`onDelete` callbacks](#callback-ondelete). Handles for tables which have a declared primary key field also expose [`onUpdate` callbacks](#callback-onupdate). Table handles also offer the ability to find subscribed rows by unique index.
+
+| Name                                                   | Description                                                                     |
+|--------------------------------------------------------|---------------------------------------------------------------------------------|
+| [Accessing rows](#accessing-rows)                      | Iterate over or count subscribed rows.                                          |
+| [`onInsert` callback](#callback-oninsert)              | Register a function to run when a row is added to the client cache.             |
+| [`onDelete` callback](#callback-ondelete)              | Register a function to run when a row is removed from the client cache.         |
+| [`onUpdate` callback](#callback-onupdate)              | Register a functioNto run when a subscribed row is replaced with a new version. |
+| [Unique index access](#unique-constraint-index-access) | Seek a subscribed row by the value in its unique or primary key column.         |
+| [BTree index access](#btree-index-access)              | Not supported.                                                                  |
+
+### Accessing rows
+
+#### Method `count`
+
+```typescript
+TableHandle.count(): number
+```
+
+Returns the number of rows of this table resident in the client cache, i.e. the total number which match any subscribed query.
+
+#### Method `iter`
+
+```typescript
+TableHandle.iter(): Iterable<Row>
+```
+
+An iterator over all the subscribed rows in the client cache, i.e. those which match any subscribed query.
+
+The `Row` type will be an autogenerated type which matches the row type defined by the module.
+
+### Callback `onInsert`
+
+```typescript
+TableHandle.onInsert(
+    callback: (ctx: EventContext, row: Row) => void
+): void;
+
+TableHandle.removeOnInsert(
+    callback: (ctx: EventContext, row: Row) => void
+): void;
+```
+
+The `onInsert` callback runs whenever a new row is inserted into the client cache, either when applying a subscription or being notified of a transaction. The passed [`EventContext`](#type-eventcontext) contains an [`Event`](#type-event) which can identify the change which caused the insertion, and also allows the callback to interact with the connection, inspect the client cache and invoke reducers.
+
+The `Row` type will be an autogenerated type which matches the row type defined by the module.
+
+`removeOnInsert` may be used to un-register a previously-registered `onInsert` callback.
+
+### Callback `onDelete`
+
+```typescript
+TableHandle.onDelete(
+    callback: (ctx: EventContext, row: Row) => void
+): void;
+
+TableHandle.removeOnDelete(
+    callback: (ctx: EventContext, row: Row) => void
+): void;
+```
+
+The `onDelete` callback runs whenever a previously-resident row is deleted from the client cache.
+
+The `Row` type will be an autogenerated type which matches the row type defined by the module.
+
+`removeOnDelete` may be used to un-register a previously-registered `onDelete` callback.
+
+### Callback `onUpdate`
+
+```typescript
+TableHandle.onUpdate(
+    callback: (ctx: EventContext, old: Row, new: Row) => void
+): void;
+
+TableHandle.removeOnUpdate(
+    callback: (ctx: EventContext, old: Row, new: Row) => void
+): void;
+```
+
+The `onUpdate` callback runs whenever an already-resident row in the client cache is updated, i.e. replaced with a new row that has the same primary key.
+
+Only tables with a declared primary key expose `onUpdate` callbacks. Handles for tables without a declared primary key will not have `onUpdate` or `removeOnUpdate` methods.
+
+The `Row` type will be an autogenerated type which matches the row type defined by the module.
+
+`removeOnUpdate` may be used to un-register a previously-registered `onUpdate` callback.
+
+### Unique constraint index access
+
+For each unique constraint on a table, its table handle has a field whose name is the unique column name. This field is a unique index handle. The unique index handle has a method `.find(desired_val: Col) -> Row | undefined`, where `Col` is the type of the column, and `Row` the type of rows. If a row with `desired_val` in the unique column is resident in the client cache, `.find` returns it.
+
+### BTree index access
+
+The SpacetimeDB TypeScript client SDK does not support non-unique BTree indexes.
+
+## Observe and invoke reducers
+
+All [`DbContext`](#interface-dbcontext) implementors, including [`DbConnection`](#type-dbconnection) and [`EventContext`](#type-eventcontext), have fields `.reducers`, which in turn has methods for invoking reducers defined by the module and registering callbacks on it.
+
+Each reducer defined by the module has three methods on the `.reducers`:
+
+- An invoke method, whose name is the reducer's name converted to camel case, like `setName`. This requests that the module run the reducer.
+- A callback registation method, whose name is prefixed with `on`, like `onSetName`. This registers a callback to run whenever we are notified that the reducer ran, including successfully committed runs and runs we requested which failed. This method returns a callback id, which can be passed to the callback remove method.
+- A callback remove method, whose name is prefixed with `removeOn`, like `removeOnSetName`. This cancels a callback previously registered via the callback registration method.
+
+## Identify a client
+
+### Type `Identity`
+
+```rust
+spacetimedb_sdk::Identity
+```
+
+A unique public identifier for a client connected to a database.
+
+### Type `ConnectionId`
+
+```rust
+spacetimedb_sdk::ConnectionId
+```
+
+An opaque identifier for a client connection to a database, intended to differentiate between connections from the same [`Identity`](#type-identity).

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -300,6 +300,8 @@ SubscriptionBuilder.subscribe(queries: string | string[]): SubscriptionHandle
 
 Subscribe to a set of queries.
 
+See [the SpacetimeDB SQL Reference](/docs/sql#subscriptions) for information on the queries SpacetimeDB supports as subscriptions.
+
 ##### Method `subscribeToAllTables`
 
 ```typescript

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -305,7 +305,7 @@ See [the SpacetimeDB SQL Reference](/docs/sql#subscriptions) for information on 
 ##### Method `subscribeToAllTables`
 
 ```typescript
-SubscriptionBuilder.subscribe_to_all_tables(): void
+SubscriptionBuilder.subscribeToAllTables(): void
 ```
 
 Subscribe to all rows from all tables. This method is provided as a convenience for simple clients. The same connection must not mix `subscribeToAllTables` with [`subscribe` to specific queries](#method-subscribe). Doing so may cause errors or corrupt the client cache, leading to local queries returning incorrect results. The subscription initiated by `subscribeToAllTables` cannot be canceled after it is initiated.

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -98,7 +98,7 @@ A connection to a remote database is represented by the `module_bindings.DbConne
 DbConnection.builder(): DbConnectionBuilder
 ```
 
-Construct a `DbConnection` by calling `DbConnection.builder()` and chaining configuration methods, then calling `.build()`. You must at least specify `withUri`, to supply the URI of the SpacetimeDB to which you published your module, and `with_module_name`, to supply the human-readable SpacetimeDB domain name or the raw `Identity` which identifies the module.
+Construct a `DbConnection` by calling `DbConnection.builder()` and chaining configuration methods, then calling `.build()`. You must at least specify `withUri`, to supply the URI of the SpacetimeDB to which you published your module, and `withModuleName`, to supply the human-readable SpacetimeDB domain name or the raw `Identity` which identifies the module.
 
 | Name                                                  | Description                                                                          |
 |-------------------------------------------------------|--------------------------------------------------------------------------------------|

--- a/docs/sdks/typescript/index.md
+++ b/docs/sdks/typescript/index.md
@@ -73,18 +73,24 @@ spacetime generate --lang typescript \
 Import the `module_bindings` in your client's _main_ file:
 
 ```typescript
-import { SpacetimeDBClient, Identity } from '@clockworklabs/spacetimedb-sdk';
+import * as moduleBindings from './module_bindings/index';
+```
 
-import * as module_bindings from './module_bindings/index';
+You may also need to import some definitions from the SDK library:
+
+```typescript
+import {
+  Identity, ConnectionId, Event, ReducerEvent
+} from '@clockworklabs/spacetimedb-sdk';
 ```
 
 ## Type `DbConnection`
 
 ```typescript
-module_bindings.DbConnection
+DbConnection
 ```
 
-A connection to a remote database is represented by the `module_bindings.DbConnection` type. This type is generated per-module, and contains information about the types, tables and reducers defined by your module.
+A connection to a remote database is represented by the `DbConnection` type. This type is generated per-module, and contains information about the types, tables and reducers defined by your module.
 
 | Name                                                      | Description                                                                                      |
 |-----------------------------------------------------------|--------------------------------------------------------------------------------------------------|
@@ -95,7 +101,9 @@ A connection to a remote database is represented by the `module_bindings.DbConne
 ### Connect to a module
 
 ```typescript
-DbConnection.builder(): DbConnectionBuilder
+class DbConnection {
+  public static builder(): DbConnectionBuilder
+}
 ```
 
 Construct a `DbConnection` by calling `DbConnection.builder()` and chaining configuration methods, then calling `.build()`. You must at least specify `withUri`, to supply the URI of the SpacetimeDB to which you published your module, and `withModuleName`, to supply the human-readable SpacetimeDB domain name or the raw `Identity` which identifies the module.
@@ -113,7 +121,9 @@ Construct a `DbConnection` by calling `DbConnection.builder()` and chaining conf
 #### Method `withUri`
 
 ```typescript
-DbConnectionBuilder.withUri(uri: string): DbConnectionBuilder
+class DbConnectionBuilder {
+  public withUri(uri: string): DbConnectionBuilder
+}
 ```
 
 Configure the URI of the SpacetimeDB instance or cluster which hosts the remote module.
@@ -121,30 +131,34 @@ Configure the URI of the SpacetimeDB instance or cluster which hosts the remote 
 #### Method `withModuleName`
 
 ```typescript
-DbConnectionBuilder.withModuleName(name_or_identity: string): DbConnectionBuilder
+class DbConnectionBuilder {
+  public withModuleName(name_or_identity: string): DbConnectionBuilder
+}
 
 ```
 
-Configure the SpacetimeDB domain name or `Identity` of the remote module which identifies it within the SpacetimeDB instance or cluster.
+Configure the SpacetimeDB domain name or hex string encoded `Identity` of the remote module which identifies it within the SpacetimeDB instance or cluster.
 
 #### Callback `onConnect`
 
 ```typescript
-DbConnectionBuilder.onConnect(
+class DbConnectionBuilder {
+  public onConnect(
     callback: (ctx: DbConnection, identity: Identity, token: string) => void
-): DbConnectionBuilder
+  ): DbConnectionBuilder
+}
 ```
 
 Chain a call to `.onConnect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote module. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`withToken`](#method-withtoken) to authenticate the same user in future connections.
 
-This interface may change in an upcoming release as we rework SpacetimeDB's authentication model.
-
 #### Callback `onConnectError`
 
 ```typescript
-DbConnectionBuilder.onConnectError(
+class DbConnectionBuilder {
+  public onConnectError(
     callback: (ctx: ErrorContext, error: Error) => void
-): DbConnectionBuilder
+  ): DbConnectionBuilder
+}
 ```
 
 Chain a call to `.onConnectError(callback)` to your builder to register a callback to run when your connection fails.
@@ -152,10 +166,11 @@ Chain a call to `.onConnectError(callback)` to your builder to register a callba
 #### Callback `onDisconnect`
 
 ```typescript
-DbConnectionBuilder.onDisconnect(
+class DbConnectionBuilder {
+  public onDisconnect(
     callback: (ctx: ErrorContext, error: Error | null) => void
-): DbConnectionBuilder
-
+  ): DbConnectionBuilder
+}
 ```
 
 Chain a call to `.onDisconnect(callback)` to your builder to register a callback to run when your `DbConnection` disconnects from the remote module, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error.
@@ -163,7 +178,9 @@ Chain a call to `.onDisconnect(callback)` to your builder to register a callback
 #### Method `withToken`
 
 ```typescript
-DbConnectionBuilder.withToken(token: string | null): DbConnectionBuilder
+class DbConnectionBuilder {
+  public withToken(token?: string): DbConnectionBuilder
+}
 ```
 
 Chain a call to `.withToken(token)` to your builder to provide an OpenID Connect compliant JSON Web Token to authenticate with, or to explicitly select an anonymous connection. If this method is not called or `null` is passed, SpacetimeDB will generate a new `Identity` and sign a new private access token for the connection.
@@ -172,7 +189,9 @@ Chain a call to `.withToken(token)` to your builder to provide an OpenID Connect
 #### Method `build`
 
 ```typescript
-DbConnectionBuilder.build(): DbConnection
+class DbConnectionBuilder {
+  public build(): DbConnection
+}
 ```
 
 After configuring the connection and registering callbacks, attempt to open the connection.
@@ -181,24 +200,28 @@ After configuring the connection and registering callbacks, attempt to open the 
 
 #### Field `db`
 
-```rust
-DbConnection.db: RemoteTables
+```typescript
+class DbConnection {
+  public db: RemoteTables
+}
 ```
 
 The `db` field of the `DbConnection` provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
 
 #### Field `reducers`
 
-```rust
-DbConnection.reducers: RemoteReducers
+```typescript
+class DbConnection {
+  public reducers: RemoteReducers
+}
 ```
 
 The `reducers` field of the `DbConnection` provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
 
 ## Interface `DbContext`
 
-```rust
-interface spacetimedb_sdk.DbContext<
+```typescript
+interface DbContext<
     DbView,
     Reducers,
 >
@@ -219,7 +242,9 @@ The `DbContext` interface is implemented by connections and contexts to *every* 
 #### Field `db`
 
 ```typescript
-DbConnection.db: DbView
+interface DbContext {
+  db: DbView
+}
 ```
 
 The `db` field of a `DbContext` provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
@@ -227,7 +252,9 @@ The `db` field of a `DbContext` provides access to the subscribed view of the re
 #### Field `reducers`
 
 ```typescript
-DbConnection.reducers: Reducers
+interface DbContext {
+  reducers: Reducers
+}
 ```
 
 The `reducers` field of a `DbContext` provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
@@ -235,7 +262,9 @@ The `reducers` field of a `DbContext` provides access to reducers exposed by the
 ### Method `disconnect`
 
 ```typescript
-DbContext.disconnect(): void
+interface DbContext {
+  disconnect(): void
+}
 ```
 
 Gracefully close the `DbConnection`. Throws an error if the connection is already disconnected.
@@ -250,7 +279,7 @@ Gracefully close the `DbConnection`. Throws an error if the connection is alread
 #### Type `SubscriptionBuilder`
 
 ```typescript
-spacetimedb_sdk::SubscriptionBuilder
+SubscriptionBuilder
 ```
 
 | Name                                                                           | Description                                                     |
@@ -264,8 +293,9 @@ spacetimedb_sdk::SubscriptionBuilder
 ##### Constructor `ctx.subscriptionBuilder()`
 
 ```typescript
-DbContext.subscriptionBuilder(): SubscriptionBuilder
-
+interface DbContext {
+  subscriptionBuilder(): SubscriptionBuilder
+}
 ```
 
 Subscribe to queries by calling `ctx.subscription_builder()` and chaining configuration methods, then calling `.subscribe(queries)`.
@@ -273,9 +303,11 @@ Subscribe to queries by calling `ctx.subscription_builder()` and chaining config
 ##### Callback `onApplied`
 
 ```typescript
-SubscriptionBuilder.onApplied(
+class SubscriptionBuilder {
+  public onApplied(
     callback: (ctx: SubscriptionEventContext) => void
-): SubscriptionBuilder
+  ): SubscriptionBuilder
+}
 ```
 
 Register a callback to run when the subscription is applied and the matching rows are inserted into the client cache.
@@ -283,10 +315,11 @@ Register a callback to run when the subscription is applied and the matching row
 ##### Callback `onError`
 
 ```typescript
-SubscriptionBuilder.onError(
+class SubscriptionBuilder {
+  public onError(
     callback: (ctx: ErrorContext, error: Error) => void
-): SubscriptionBuilder
-
+  ): SubscriptionBuilder
+}
 ```
 
 Register a callback to run if the subscription is rejected or unexpectedly terminated by the server. This is most frequently caused by passing an invalid query to [`subscribe`](#method-subscribe).
@@ -295,7 +328,9 @@ Register a callback to run if the subscription is rejected or unexpectedly termi
 ##### Method `subscribe`
 
 ```typescript
-SubscriptionBuilder.subscribe(queries: string | string[]): SubscriptionHandle
+class SubscriptionBuilder {
+  subscribe(queries: string | string[]): SubscriptionHandle
+}
 ```
 
 Subscribe to a set of queries.
@@ -305,15 +340,17 @@ See [the SpacetimeDB SQL Reference](/docs/sql#subscriptions) for information on 
 ##### Method `subscribeToAllTables`
 
 ```typescript
-SubscriptionBuilder.subscribeToAllTables(): void
+class SubscriptionBuilder {
+  subscribeToAllTables(): void
+}
 ```
 
-Subscribe to all rows from all public tables. This method is provided as a convenience for simple clients. The subscription initiated by `subscribeToAllTables ` cannot be canceled after it is initiated. You should [`subscribe` to specific queries](#method-subscribe) if you need fine-grained control over the lifecycle of your subscriptions.
+Subscribe to all rows from all public tables. This method is provided as a convenience for simple clients. The subscription initiated by `subscribeToAllTables` cannot be canceled after it is initiated. You should [`subscribe` to specific queries](#method-subscribe) if you need fine-grained control over the lifecycle of your subscriptions.
 
 #### Type `SubscriptionHandle`
 
-```rust
-module_bindings::SubscriptionHandle
+```typescript
+SubscriptionHandle
 ```
 
 A `SubscriptionHandle` represents a subscribed query or a group of subscribed queries.
@@ -330,7 +367,9 @@ The `SubscriptionHandle` does not contain or provide access to the subscribed ro
 ##### Method `isEnded`
 
 ```typescript
-SubscriptionHandle.isEnded(): bool
+class SubscriptionHandle {
+  public isEnded(): bool
+}
 ```
 
 Returns true if this subscription has been terminated due to an unsubscribe call or an error.
@@ -338,7 +377,9 @@ Returns true if this subscription has been terminated due to an unsubscribe call
 ##### Method `isActive`
 
 ```typescript
-SubscriptionHandle.isActive(): bool
+class SubscriptionHandle {
+  public isActive(): bool
+}
 ```
 
 Returns true if this subscription has been applied and has not yet been unsubscribed.
@@ -346,7 +387,9 @@ Returns true if this subscription has been applied and has not yet been unsubscr
 ##### Method `unsubscribe`
 
 ```typescript
-SubscriptionHandle.unsubscribe(): void
+class SubscriptionHandle {
+  public unsubscribe(): void
+}
 ```
 
 Terminate this subscription, causing matching rows to be removed from the client cache. Any rows removed from the client cache this way will have [`onDelete` callbacks](#callback-ondelete) run for them.
@@ -358,22 +401,25 @@ Throws an error if the subscription has already ended, either due to a previous 
 ##### Method `unsubscribeThen`
 
 ```typescript
-SubscriptionHandle.unsubscribe_then(
+class SubscriptionHandle {
+  public unsubscribeThen(
     on_end: (ctx: SubscriptionEventContext) => void
-): void
-
+  ): void
+}
 ```
 
 Terminate this subscription, and run the `onEnd` callback when the subscription is ended and its matching rows are removed from the client cache. Any rows removed from the client cache this way will have [`onDelete` callbacks](#callback-ondelete) run for them.
 
-Returns an error if the subscription has already ended, either due to a previous call to [`unsubscribe`](#method-unsubscribe) or `unsubscribe_then`, or due to an error.
+Returns an error if the subscription has already ended, either due to a previous call to [`unsubscribe`](#method-unsubscribe) or `unsubscribeThen`, or due to an error.
 
 ### Read connection metadata
 
 #### Field `isActive`
 
 ```typescript
-DbContext.isActive: bool
+interface DbContext {
+  isActive: bool
+}
 ```
 
 `true` if the connection has not yet disconnected. Note that a connection `isActive` when it is constructed, before its [`onConnect` callback](#callback-onconnect) is invoked.
@@ -381,7 +427,7 @@ DbContext.isActive: bool
 ## Type `EventContext`
 
 ```typescript
-module_bindings.EventContext
+EventContext
 ```
 
 An `EventContext` is a [`DbContext`](#interface-dbcontext) augmented with a field [`event: Event`](#type-event). `EventContext`s are passed as the first argument to row callbacks [`onInsert`](#callback-oninsert), [`onDelete`](#callback-ondelete) and [`onUpdate`](#callback-onupdate).
@@ -396,7 +442,9 @@ An `EventContext` is a [`DbContext`](#interface-dbcontext) augmented with a fiel
 ### Field `event`
 
 ```typescript
-EventContext.event: spacetimedb_sdk.Event<module_bindings.Reducer>,
+class EventContext {
+  public event: Event<Reducer>
+}
 /* other fields */
 
 ```
@@ -405,16 +453,20 @@ The [`Event`](#type-event) contained in the `EventContext` describes what happen
 
 ### Field `db`
 
-```rust
-EventContext.db: RemoteTables
+```typescript
+class EventContext {
+  public db: RemoteTables
+}
 ```
 
 The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
 
 ### Field `reducers`
 
-```rust
-EventContext.reducers: RemoteReducers
+```typescript
+class EventContext {
+  public reducers: RemoteReducers
+}
 ```
 
 The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
@@ -422,7 +474,7 @@ The `reducers` field of the context provides access to reducers exposed by the r
 ### Type `Event`
 
 ```rust
-type spacetimedb_sdk.Event<Reducer> =
+type Event<Reducer> =
   | { tag: 'Reducer'; value: ReducerEvent<Reducer> }
   | { tag: 'SubscribeApplied' }
   | { tag: 'UnsubscribeApplied' }
@@ -444,7 +496,7 @@ type spacetimedb_sdk.Event<Reducer> =
 #### Variant `Reducer`
 
 ```typescript
-{ tag: 'Reducer'; value: spacetimedb_sdk.ReducerEvent<Reducer> }
+{ tag: 'Reducer'; value: ReducerEvent<Reducer> }
 ```
 
 Event when we are notified that a reducer ran in the remote module. The [`ReducerEvent`](#type-reducerevent) contains metadata about the reducer run, including its arguments and termination status(#type-updatestatus).
@@ -497,7 +549,7 @@ This event is passed to [row callbacks](#callback-oninsert) resulting from modif
 A `ReducerEvent` contains metadata about a reducer run.
 
 ```typescript
-type spacetimedb_sdk.ReducerEvent<Reducer> = {
+type ReducerEvent<Reducer> = {
   /**
    * The time when the reducer started running.
    */
@@ -531,7 +583,7 @@ type spacetimedb_sdk.ReducerEvent<Reducer> = {
   energyConsumed?: bigint;
 
   /**
-   * The `Reducer` enum defined by the `module_bindings`, which encodes which reducer ran and its arguments.
+   * The `Reducer` enum defined by the `moduleBindings`, which encodes which reducer ran and its arguments.
    */
   reducer: Reducer;
 };
@@ -540,7 +592,7 @@ type spacetimedb_sdk.ReducerEvent<Reducer> = {
 ### Type `UpdateStatus`
 
 ```typescript
-type spacetimedb_sdk.UpdateStatus =
+type UpdateStatus =
   | { tag: 'Committed'; value: __DatabaseUpdate }
   | { tag: 'Failed'; value: string }
   | { tag: 'OutOfEnergy' };
@@ -579,7 +631,7 @@ The reducer was aborted due to insufficient energy balance of the module owner.
 ### Type `Reducer`
 
 ```rust
-type module_bindings.Reducer =
+type Reducer =
   | { name: 'ReducerA'; args: ReducerA }
   | { name: 'ReducerB'; args: ReducerB }
 ```
@@ -599,7 +651,9 @@ A `ReducerEventContext` is a [`DbContext`](#interface-dbcontext) augmented with 
 ### Field `event`
 
 ```typescript
-ReducerEventContext.event: spacetimedb_sdk.ReducerEvent<module_bindings.Reducer>,
+class ReducerEventContext {
+  public event: ReducerEvent<Reducer>
+}
 ```
 
 The [`ReducerEvent`](#type-reducerevent) contained in the `ReducerEventContext` has metadata about the reducer which ran.
@@ -607,7 +661,9 @@ The [`ReducerEvent`](#type-reducerevent) contained in the `ReducerEventContext` 
 ### Field `db`
 
 ```typescript
-ReducerEventContext.db: RemoteTables
+class ReducerEventContext {
+  public db: RemoteTables
+}
 ```
 
 The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
@@ -615,7 +671,9 @@ The `db` field of the context provides access to the subscribed view of the remo
 ### Field `reducers`
 
 ```typescript
-ReducerEventContext.reducers: RemoteReducers
+class ReducerEventContext {
+  public reducers: RemoteReducers
+}
 ```
 
 The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
@@ -632,7 +690,9 @@ A `SubscriptionEventContext` is a [`DbContext`](#interface-dbcontext). Unlike th
 ### Field `db`
 
 ```typescript
-SubscriptionEventContext.db: RemoteTables
+class SubscriptionEventContext {
+  public db: RemoteTables
+}
 ```
 
 The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
@@ -640,7 +700,9 @@ The `db` field of the context provides access to the subscribed view of the remo
 ### Field `reducers`
 
 ```typescript
-SubscriptionEventContext.reducers: RemoteReducers
+class SubscriptionEventContext {
+  public reducers: RemoteReducers
+}
 ```
 
 The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
@@ -659,13 +721,17 @@ An `ErrorContext` is a [`DbContext`](#interface-dbcontext) augmented with a fiel
 ### Field `event`
 
 ```typescript
-ErrorContext.event: Error
+class ErrorContext {
+  public event: Error
+}
 ```
 
 ### Field `db`
 
 ```typescript
-ErrorContext.db: RemoteTables
+class ErrorContext {
+  public db: RemoteTables
+}
 ```
 
 The `db` field of the context provides access to the subscribed view of the remote database's tables. See [Access the client cache](#access-the-client-cache).
@@ -673,7 +739,9 @@ The `db` field of the context provides access to the subscribed view of the remo
 ### Field `reducers`
 
 ```typescript
-ErrorContext.reducers: RemoteReducers
+class ErrorContext {
+  public reducers: RemoteReducers
+}
 ```
 
 The `reducers` field of the context provides access to reducers exposed by the remote module. See [Observe and invoke reducers](#observe-and-invoke-reducers).
@@ -698,7 +766,9 @@ Each table defined by a module has an accessor method, whose name is the table n
 #### Method `count`
 
 ```typescript
-TableHandle.count(): number
+class TableHandle {
+  public count(): number
+}
 ```
 
 Returns the number of rows of this table resident in the client cache, i.e. the total number which match any subscribed query.
@@ -706,7 +776,9 @@ Returns the number of rows of this table resident in the client cache, i.e. the 
 #### Method `iter`
 
 ```typescript
-TableHandle.iter(): Iterable<Row>
+class TableHandle {
+  public iter(): Iterable<Row>
+}
 ```
 
 An iterator over all the subscribed rows in the client cache, i.e. those which match any subscribed query.
@@ -716,13 +788,15 @@ The `Row` type will be an autogenerated type which matches the row type defined 
 ### Callback `onInsert`
 
 ```typescript
-TableHandle.onInsert(
+class TableHandle {
+  public onInsert(
     callback: (ctx: EventContext, row: Row) => void
-): void;
+  ): void;
 
-TableHandle.removeOnInsert(
+  public removeOnInsert(
     callback: (ctx: EventContext, row: Row) => void
-): void;
+  ): void;
+}
 ```
 
 The `onInsert` callback runs whenever a new row is inserted into the client cache, either when applying a subscription or being notified of a transaction. The passed [`EventContext`](#type-eventcontext) contains an [`Event`](#type-event) which can identify the change which caused the insertion, and also allows the callback to interact with the connection, inspect the client cache and invoke reducers.
@@ -734,13 +808,15 @@ The `Row` type will be an autogenerated type which matches the row type defined 
 ### Callback `onDelete`
 
 ```typescript
-TableHandle.onDelete(
+class TableHandle {
+  public onDelete(
     callback: (ctx: EventContext, row: Row) => void
-): void;
+  ): void;
 
-TableHandle.removeOnDelete(
+  public removeOnDelete(
     callback: (ctx: EventContext, row: Row) => void
-): void;
+  ): void;
+}
 ```
 
 The `onDelete` callback runs whenever a previously-resident row is deleted from the client cache.
@@ -752,13 +828,15 @@ The `Row` type will be an autogenerated type which matches the row type defined 
 ### Callback `onUpdate`
 
 ```typescript
-TableHandle.onUpdate(
+class TableHandle {
+  public onUpdate(
     callback: (ctx: EventContext, old: Row, new: Row) => void
-): void;
+  ): void;
 
-TableHandle.removeOnUpdate(
+  public removeOnUpdate(
     callback: (ctx: EventContext, old: Row, new: Row) => void
-): void;
+  ): void;
+}
 ```
 
 The `onUpdate` callback runs whenever an already-resident row in the client cache is updated, i.e. replaced with a new row that has the same primary key.
@@ -771,7 +849,7 @@ The `Row` type will be an autogenerated type which matches the row type defined 
 
 ### Unique constraint index access
 
-For each unique constraint on a table, its table handle has a field whose name is the unique column name. This field is a unique index handle. The unique index handle has a method `.find(desired_val: Col) -> Row | undefined`, where `Col` is the type of the column, and `Row` the type of rows. If a row with `desired_val` in the unique column is resident in the client cache, `.find` returns it.
+For each unique constraint on a table, its table handle has a field whose name is the unique column name. This field is a unique index handle. The unique index handle has a method `.find(desiredValue: Col) -> Row | undefined`, where `Col` is the type of the column, and `Row` the type of rows. If a row with `desiredValue` in the unique column is resident in the client cache, `.find` returns it.
 
 ### BTree index access
 
@@ -792,7 +870,7 @@ Each reducer defined by the module has three methods on the `.reducers`:
 ### Type `Identity`
 
 ```rust
-spacetimedb_sdk::Identity
+Identity
 ```
 
 A unique public identifier for a client connected to a database.
@@ -800,7 +878,7 @@ A unique public identifier for a client connected to a database.
 ### Type `ConnectionId`
 
 ```rust
-spacetimedb_sdk::ConnectionId
+ConnectionId
 ```
 
 An opaque identifier for a client connection to a database, intended to differentiate between connections from the same [`Identity`](#type-identity).


### PR DESCRIPTION
Based on #172 . What I did was, I deleted the whole existing TypeScript ref, pasted in the new Rust ref, and then replaced all the Rust code with TypeScript.

I'm not super happy with how I'm formatting the code blocks, but :shrug: I think it's good enough.