### PR TITLE
Updates to blackhol.io tutorials

### DIFF
--- a/docs/unity/part-3.md
+++ b/docs/unity/part-3.md
@@ -336,12 +336,6 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
     ctx.db.logged_out_player().insert(player);
     ctx.db.player().identity().delete(&ctx.sender);
 
-    // Remove any circles from the arena
-    for circle in ctx.db.circle().player_id().filter(&player_id) {
-        ctx.db.entity().entity_id().delete(&circle.entity_id);
-        ctx.db.circle().entity_id().delete(&circle.entity_id);
-    }
-
     Ok(())
 }
 ```

--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -198,7 +198,7 @@ Next, add the following reducer to the `Module` class of your `Lib.cs` file.
 [Reducer]
 public static void UpdatePlayerInput(ReducerContext ctx, DbVector2 direction)
 {
-    var player = ctx.Db.player.identity.Find(ctx.CallerIdentity) ?? throw new Exception("Player not found");				
+    var player = ctx.Db.player.identity.Find(ctx.Sender) ?? throw new Exception("Player not found");				
     foreach (var c in ctx.Db.circle.player_id.Filter(player.player_id))
     {
         var circle = c;
@@ -210,7 +210,7 @@ public static void UpdatePlayerInput(ReducerContext ctx, DbVector2 direction)
 }
 ```
 
-This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.CallerIdentity` value is not set by the client. Instead `ctx.CallerIdentity` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
+This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.Sender` value is not set by the client. Instead `ctx.Sender` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
 :::
 
 Finally, let's schedule a reducer to run every 50 milliseconds to move the player's circles around based on the most recently set player input.


### PR DESCRIPTION
### Changes:
Page 3 - Fix duplicate code in Rust "disconnect reducer" instructions. The first instance of the `disconnect` reducer should not contain the `circle` cleanup code, as this is added to the `disconnect` reducer later in the tutorial.
Page 4 - Update use of `CallerIdentity` to `Sender` in C# instructions.