### PR TITLE
Updated with corrected table names to lower case, for compatibility w…

### DIFF
--- a/docs/modules/c-sharp/quickstart.md
+++ b/docs/modules/c-sharp/quickstart.md
@@ -82,7 +82,7 @@ For each `User`, we'll store their `Identity`, an optional name they can set to 
 In `server/Lib.cs`, add the definition of the table `User` to the `Module` class:
 
 ```csharp
-[Table(Name = "User", Public = true)]
+[Table(Name = "user", Public = true)]
 public partial class User
 {
     [PrimaryKey]
@@ -97,11 +97,11 @@ For each `Message`, we'll store the `Identity` of the user who sent it, the `Tim
 In `server/Lib.cs`, add the definition of the table `Message` to the `Module` class:
 
 ```csharp
-[Table(Name = "Message", Public = true)]
+[Table(Name = "message", Public = true)]
 public partial class Message
 {
     public Identity Sender;
-    public long Sent;
+    public Timestamp Sent;
     public string Text = "";
 }
 ```
@@ -122,11 +122,11 @@ public static void SetName(ReducerContext ctx, string name)
 {
     name = ValidateName(name);
 
-    var user = ctx.Db.User.Identity.Find(ctx.Sender);
+    var user = ctx.Db.user.Identity.Find(ctx.Sender);
     if (user is not null)
     {
         user.Name = name;
-        ctx.Db.User.Identity.Update(user);
+        ctx.Db.user.Identity.Update(user);
     }
 }
 ```
@@ -165,12 +165,12 @@ public static void SendMessage(ReducerContext ctx, string text)
 {
     text = ValidateMessage(text);
     Log.Info(text);
-    ctx.Db.Message.Insert(
+    ctx.Db.message.Insert(
         new Message
         {
             Sender = ctx.Sender,
             Text = text,
-            Sent = ctx.Timestamp.MicrosecondsSinceUnixEpoch,
+            Sent = ctx.Timestamp,
         }
     );
 }
@@ -210,20 +210,20 @@ In `server/Lib.cs`, add the definition of the connect reducer to the `Module` cl
 public static void ClientConnected(ReducerContext ctx)
 {
     Log.Info($"Connect {ctx.Sender}");
-    var user = ctx.Db.User.Identity.Find(ctx.Sender);
+    var user = ctx.Db.user.Identity.Find(ctx.Sender);
 
     if (user is not null)
     {
         // If this is a returning user, i.e., we already have a `User` with this `Identity`,
         // set `Online: true`, but leave `Name` and `Identity` unchanged.
         user.Online = true;
-        ctx.Db.User.Identity.Update(user);
+        ctx.Db.user.Identity.Update(user);
     }
     else
     {
         // If this is a new user, create a `User` object for the `Identity`,
         // which is online, but hasn't set a name.
-        ctx.Db.User.Insert(
+        ctx.Db.user.Insert(
             new User
             {
                 Name = null,
@@ -243,13 +243,13 @@ Add the following code after the `OnConnect` handler:
 [Reducer(ReducerKind.ClientDisconnected)]
 public static void ClientDisconnected(ReducerContext ctx)
 {
-    var user = ctx.Db.User.Identity.Find(ctx.Sender);
+    var user = ctx.Db.user.Identity.Find(ctx.Sender);
 
     if (user is not null)
     {
         // This user should exist, so set `Online: false`.
         user.Online = false;
-        ctx.Db.User.Identity.Update(user);
+        ctx.Db.user.Identity.Update(user);
     }
     else
     {
@@ -311,6 +311,8 @@ spacetime sql quickstart-chat "SELECT * FROM Message"
 
 ## What's next?
 
-You've just set up your first database in SpacetimeDB! The next step would be to create a client module that interacts with this module. You can use any of SpacetimDB's supported client languages to do this. Take a look at the quick start guide for your client language of choice: [Rust](/docs/sdks/rust/quickstart), [C#](/docs/sdks/c-sharp/quickstart), or [TypeScript](/docs/sdks/typescript/quickstart).
+You've just set up your first database in SpacetimeDB! You can find the full code for this client [in the C# server module example](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/tree/master/examples~/quickstart-chat/server).
+
+The next step would be to create a client module that interacts with this module. You can use any of SpacetimDB's supported client languages to do this. Take a look at the quick start guide for your client language of choice: [Rust](/docs/sdks/rust/quickstart), [C#](/docs/sdks/c-sharp/quickstart), or [TypeScript](/docs/sdks/typescript/quickstart).
 
 If you are planning to use SpacetimeDB with the Unity game engine, you can skip right to the [Unity Comprehensive Tutorial](/docs/unity/part-1) or check out our example game, [BitcraftMini](/docs/unity/part-3).

--- a/docs/sdks/c-sharp/quickstart.md
+++ b/docs/sdks/c-sharp/quickstart.md
@@ -203,7 +203,9 @@ void OnDisconnect(DbConnection conn, Exception? e)
     if (e != null)
     {
         Console.Write($"Disconnected abnormally: {e}");
-    } else {
+    }
+    else
+    {
         Console.Write($"Disconnected normally.");
     }
 }
@@ -551,7 +553,7 @@ dotnet run --project client
 
 Congratulations! You've built a simple chat app using SpacetimeDB.
 
-You can find the full code for this client [in the C# client SDK's examples](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/tree/master/examples~/quickstart/client).
+You can find the full code for this client [in the C# client SDK's examples](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/tree/master/examples~/quickstart-chat/client).
 
 Check out the [C# client SDK Reference](/docs/sdks/c-sharp) for a more comprehensive view of the SpacetimeDB C# client SDK.
 

--- a/docs/sdks/c-sharp/quickstart.md
+++ b/docs/sdks/c-sharp/quickstart.md
@@ -71,7 +71,7 @@ using SpacetimeDB.Types;
 using System.Collections.Concurrent;
 ```
 
-We will also need to create some global variables that will be explained when we use them later.
+We will also need to create some global variables. We'll cover the `Identity` later in the `Save credentials` section. Later we'll also be setting up a second thread for handling user input. In the `Process thread` section we'll use this in the `ConcurrentQueue` to store the commands for that thread.
 
 To `Program.cs`, add:
 
@@ -153,7 +153,7 @@ DbConnection ConnectToDB()
         .WithToken(AuthToken.Token)
         .OnConnect(OnConnected)
         .OnConnectError(OnConnectError)
-        .OnDisconnect(OnDisconnect)
+        .OnDisconnect(OnDisconnected)
         .Build();
     return conn;
 }
@@ -198,7 +198,7 @@ To `Program.cs`, add:
 
 ```csharp
 /// Our `OnDisconnect` callback: print a note, then exit the process.
-void OnDisconnect(DbConnection conn, Exception? e)
+void OnDisconnected(DbConnection conn, Exception? e)
 {
     if (e != null)
     {
@@ -321,6 +321,9 @@ To `Program.cs`, add:
 /// Our `Message.OnInsert` callback: print new messages.
 void Message_OnInsert(EventContext ctx, Message insertedValue)
 {
+    // We are filtering out messages inserted during the subscription being applied,
+    // since we will be printing those in the OnSubscriptionApplied callback,
+    // where we will be able to first sort the messages before printing.
     if (ctx.Event is not Event<Reducer>.SubscribeApplied)
     {
         PrintMessage(ctx.Db, insertedValue);


### PR DESCRIPTION
### Changes:
1. Updated C# quickstart-chat server module and client SDK to use lower-case "names" for tables, in order to:
- Provide better cross-compatibility with Rust quickstart-chat tutorials.
- Provide parity with the sample code in the repo, which required lower-case names for automated tests to successfully pass.
2. Updated sample code URLs at end of each page to point to the new location in the SDK repo.

Changes correspond create parody with updated made to the SDK sample code: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/258 