### PR TITLE
Fix code error and wrong code block

### DIFF
--- a/docs/modules/rust/quickstart.md
+++ b/docs/modules/rust/quickstart.md
@@ -110,7 +110,7 @@ To `server/src/lib.rs`, add:
 pub fn set_name(ctx: &ReducerContext, name: String) -> Result<(), String> {
     let name = validate_name(name)?;
     if let Some(user) = ctx.db.user().identity().find(ctx.sender) {
-        ctx.db.user().identity().update(User { name: Some(name), ..user })
+        ctx.db.user().identity().update(User { name: Some(name), ..user });
         Ok(())
     } else {
         Err("Cannot set name for unknown user".to_string())
@@ -205,7 +205,8 @@ pub fn client_connected(ctx: &ReducerContext) {
             online: true,
         });
     }
-}```
+}
+```
 
 Similarly, whenever a client disconnects, the module will run the `#[reducer(client_disconnected)]` reducer if it's defined. By convention, it's named `client_disconnected`. We'll use it to un-set the `online` status of the `User` for the disconnected client.
 


### PR DESCRIPTION
This fixes a broken code block and a missing semicolon in one of the code blocks.