### PR TITLE
Bump typescript version to 1.0.2

### DIFF
--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -28,7 +28,7 @@ pnpm install
 We also need to install the `spacetime-client-sdk` package:
 
 ```bash
-pnpm install @clockworklabs/spacetimedb-sdk@1.0.1
+pnpm install @clockworklabs/spacetimedb-sdk@1.0.2
 ```
 
 > If you are using another package manager like `yarn` or `npm`, the same steps should work with the appropriate commands for those tools.


### PR DESCRIPTION
This bumps the typescript version to 1.0.2 which contains a compression bug fix.
