### PR TITLE
Remove stale references to removed CLI functions

### DIFF
--- a/docs/http/database.md
+++ b/docs/http/database.md
@@ -129,8 +129,6 @@ Accessible through the CLI as `spacetime delete <identity>`.
 
 Get the names this datbase can be identified by.
 
-Accessible through the CLI as `spacetime dns reverse-lookup <identity>`.
-
 #### Returns
 
 Returns JSON in the form:
@@ -205,8 +203,6 @@ If any of the new names already exist but the identity provided in the `Authoriz
 ## `GET /v1/database/:name_or_identity/identity`
 
 Get the identity of a database.
-
-Accessible through the CLI as `spacetime dns lookup <name>`.
 
 #### Returns
 

--- a/docs/http/identity.md
+++ b/docs/http/identity.md
@@ -16,8 +16,6 @@ The HTTP endpoints in `/v1/identity` allow clients to generate and manage Spacet
 
 Create a new identity.
 
-Accessible through the CLI as `spacetime identity new`.
-
 #### Returns
 
 Returns JSON in the form:
@@ -62,8 +60,6 @@ Returns a response of content-type `application/pem-certificate-chain`.
 ## `POST /v1/identity/:identity/set-email`
 
 Associate an email with a Spacetime identity.
-
-Accessible through the CLI as `spacetime identity set-email <identity> <email>`.
 
 #### Parameters
 


### PR DESCRIPTION
Removed references to `spacetime identity` and `spacetime dns`, since these were removed.

I did a quick scan of other references to the CLI here, and didn't _notice_ any other stale references, but I could have missed something. We can always open more PRs.