### PR TITLE
Updated to correct old timestamp format.

### DIFF
--- a/docs/unity/part-4.md
+++ b/docs/unity/part-4.md
@@ -317,7 +317,7 @@ ctx.db
     .move_all_players_timer()
     .try_insert(MoveAllPlayersTimer {
         scheduled_id: 0,
-        scheduled_at: ScheduleAt::Interval(Duration::from_millis(50).as_micros() as u64),
+        scheduled_at: ScheduleAt::Interval(Duration::from_millis(50).into()),
     })?;
 ```
 :::


### PR DESCRIPTION
Error in documentation, for Blackholio quickstart, that used the older timestamp code. Corrected to bring it up to date with the repo example found here: https://github.com/clockworklabs/Blackholio/blob/8d668332884b366587d4e63606dfa4f4a9899f33/server-rust/src/lib.rs#L138