### PR TITLE
Table name is 'messages' not 'Messages'

### DIFF
--- a/docs/modules/c-sharp/quickstart.md
+++ b/docs/modules/c-sharp/quickstart.md
@@ -298,7 +298,7 @@ info: Hello, World!
 SpacetimeDB supports a subset of the SQL syntax so that you can easily query the data of your database. We can run a query using the `sql` command.
 
 ```bash
-spacetime sql quickstart-chat "SELECT * FROM Message"
+spacetime sql quickstart-chat "SELECT * FROM message"
 ```
 
 ```bash


### PR DESCRIPTION
Was just following the QuickStart and came across this.

Changing the command in the quickstart guide from 
`spacetime sql quickstart-chat "SELECT * FROM Message"`
to
`spacetime sql quickstart-chat "SELECT * FROM message"`

As the `message` table in the code block starts with a lowercase `m`