### PR TITLE
Small fix on part-3.md

### DIFF
--- a/docs/unity/part-3.md
+++ b/docs/unity/part-3.md
@@ -106,7 +106,7 @@ const uint TARGET_FOOD_COUNT = 600;
 public static float MassToRadius(uint mass) => MathF.Sqrt(mass);
 
 [Reducer]
-public static void SpawnFood(ReducerContext ctx, SpawnFoodTimer timer)
+public static void SpawnFood(ReducerContext ctx)
 {
     if (ctx.Db.player.Count == 0) //Are there no players yet?
     {


### PR DESCRIPTION
The instruction on c# stated that it would show an error because `SpawnFoodTimer` was not in the method signature but in the initial Implementation it is, so I removed it.