### PR TITLE
CI - Add release branch check

### DIFF
--- a/.github/workflows/git-tree-checks.yml
+++ b/.github/workflows/git-tree-checks.yml
@@ -1,0 +1,22 @@
+name: Git tree checks
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  merge_group:
+permissions: read-all
+
+jobs:
+  check_base_ref:
+    name: Release branch restriction
+    runs-on: ubuntu-latest
+    steps:
+      - if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.base.ref == 'release' &&
+          ! startsWith(github.event.pull_request.head.ref, 'release-')
+        run: |
+          echo 'Only `release-*` branches are allowed to merge into the release branch `release`.'
+          echo 'Are you **sure** that you want to merge into release?'
+          echo 'Is this **definitely** just cherrypicking commits that are already in `master`?'
+          exit 1


### PR DESCRIPTION
This check will fail if a PR is opened onto the `release` branch from a branch that doesn't look like `release-*`.

This is similar to the check we have in the C#/Unity SDK (https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/blob/release/latest/.github/workflows/check-pr-base.yml).