### PR TITLE
TS quickstart: Install latest SDK, not specific version

### DIFF
--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -28,7 +28,7 @@ pnpm install
 We also need to install the `spacetime-client-sdk` package:
 
 ```bash
-pnpm install @clockworklabs/spacetimedb-sdk@1.0.2
+pnpm install @clockworklabs/spacetimedb-sdk
 ```
 
 > If you are using another package manager like `yarn` or `npm`, the same steps should work with the appropriate commands for those tools.


### PR DESCRIPTION
The version listed here was outdated and included bugs. I don't even know why we'd recommend a specific version, instead of just telling people to install the latest release.

[From a report on Discord](https://discord.com/channels/1037340874172014652/1356648963025141901/1356933593422630922).