### PR TITLE
Subscribe to all queries together in the ts quickstart.

### DIFF
--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -404,18 +404,12 @@ Add the following to your `App` function, just below `const [newMessage, setNewM
 
   useEffect(() => {
     const subscribeToQueries = (conn: DbConnection, queries: string[]) => {
-      let count = 0;
-      for (const query of queries) {
-        conn
-          ?.subscriptionBuilder()
-          .onApplied(() => {
-            count++;
-            if (count === queries.length) {
-              console.log('SDK client cache initialized.');
-            }
-          })
-          .subscribe(query);
-      }
+      conn
+        ?.subscriptionBuilder()
+        .onApplied(() => {
+          console.log('SDK client cache initialized.');
+        })
+        .subscribe(queries);
     };
 
     const onConnect = (


### PR DESCRIPTION
This is just copying the same change made in https://github.com/clockworklabs/spacetimedb-typescript-sdk/pull/173.