### PR TITLE
CI - Expand CI-triggering events

### DIFF
--- a/.github/workflows/check-cli-reference.yml
+++ b/.github/workflows/check-cli-reference.yml
@@ -1,5 +1,9 @@
 on:
   pull_request:
+  push:
+    branches:
+      - master
+  merge_group:
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
+  merge_group:
 
 jobs:
   check-links:

--- a/.github/workflows/git-tree-checks.yml
+++ b/.github/workflows/git-tree-checks.yml
@@ -3,7 +3,6 @@ name: Git tree checks
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-  merge_group:
 permissions: read-all
 
 jobs:

--- a/.github/workflows/git-tree-checks.yml
+++ b/.github/workflows/git-tree-checks.yml
@@ -3,6 +3,8 @@ name: Git tree checks
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+    branches:
+      - release
 permissions: read-all
 
 jobs:

--- a/.github/workflows/validate-nav-build.yml
+++ b/.github/workflows/validate-nav-build.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
+  merge_group:
 
 jobs:
   validate-build:


### PR DESCRIPTION
Run (most of) our CI checks on commits to `master`. I also made them run on `merge_group`, in case we decide to use a merge queue in the future. I also restricted the release branch checks to only run on the release branch.

Once this is happening, we can re-enable these status checks as required on the `release` branch, which will give us a bit security against accidentally pushing a wrong/broken thing.