### PR TITLE
Stronger wording to direct users to working unity versions

### DIFF
--- a/docs/unity/index.md
+++ b/docs/unity/index.md
@@ -12,12 +12,12 @@ Our game, called [Blackhol.io](https://github.com/ClockworkLabs/Blackholio), wil
 
 This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and programming. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
 
-We recommend using Unity `2022.3.32f1` or later. Earlier versions of Unity that utilize C# 9 (`2021.2` onward) may work, however are untested and thus may not be fully functional. This tutorial has been tested with the following Unity versions:
+SpacetimeDB supports Unity version `2022.3.32f1` or later, and this tutorial has been tested with the following Unity versions:
 
 - `2022.3.32f1 LTS`
 - `6000.0.33f1`
 
-Please file an issue [here](https://github.com/clockworklabs/spacetime-docs/issues) if you encounter an issue with a specific Unity version.
+Please file an issue [here](https://github.com/clockworklabs/spacetime-docs/issues) if you encounter an issue with a specific Unity version, but please be aware that the SpacetimeDB team is unable to offer support for issues related to versions of Unity prior to `2022.3.32f1 LTS`.
 
 ## Blackhol.io Tutorial - Basic Multiplayer
 

--- a/docs/unity/index.md
+++ b/docs/unity/index.md
@@ -12,7 +12,7 @@ Our game, called [Blackhol.io](https://github.com/ClockworkLabs/Blackholio), wil
 
 This tutorial assumes that you have a basic understanding of the Unity Editor, using a command line terminal and programming. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
 
-We recommend using Unity `2022.3.32f1` or later, but the SDK's minimum supported Unity version is `2021.2` as the SDK requires C# 9. This tutorial has been tested with the following Unity versions.
+We recommend using Unity `2022.3.32f1` or later. Earlier versions of Unity that utilize C# 9 (`2021.2` onward) may work, however are untested and thus may not be fully functional. This tutorial has been tested with the following Unity versions:
 
 - `2022.3.32f1 LTS`
 - `6000.0.33f1`

--- a/docs/unity/part-1.md
+++ b/docs/unity/part-1.md
@@ -30,7 +30,7 @@ In this section, we will guide you through the process of setting up a Unity Pro
 
 ### Step 1: Create a Blank Unity Project
 
-The SpacetimeDB Unity SDK minimum supported Unity version is `2021.2` as the SDK requires C# 9. See [the overview](.) for more information on specific supported versions.
+We recommend using Unity `2022.3.32f1` or later. Earlier versions of Unity that utilize C# 9 (`2021.2` onward) may work, however are untested and thus may not be fully functional. See [the overview](.) for more information on specific supported versions.
 
 Open Unity and create a new project by selecting "New" from the Unity Hub or going to **File -> New Project**.
 

--- a/docs/unity/part-1.md
+++ b/docs/unity/part-1.md
@@ -30,7 +30,7 @@ In this section, we will guide you through the process of setting up a Unity Pro
 
 ### Step 1: Create a Blank Unity Project
 
-We recommend using Unity `2022.3.32f1` or later. Earlier versions of Unity that utilize C# 9 (`2021.2` onward) may work, however are untested and thus may not be fully functional. See [the overview](.) for more information on specific supported versions.
+SpacetimeDB supports Unity version `2022.3.32f1` or later. See [the overview](.) for more information on specific supported versions.
 
 Open Unity and create a new project by selecting "New" from the Unity Hub or going to **File -> New Project**.
 


### PR DESCRIPTION
While Unity version `2021.2` onward may _technically_ be supported due to c# 9, it's likely to not going to work. I've tested half a dozen versions PRIOR to `2022.3.32f1` and none of them work out of the box. You will get errors like this: 
![image](https://github.com/user-attachments/assets/5de2e0d3-6c48-403c-8773-1de85476a8c0)

So, let's strongly word the version recommendation so that users are more inclined to use a working version of unity and not encounter these errors. 

ref: https://discord.com/channels/1037340874172014652/1037343198617538580/1365303831864410242
ref: https://discord.com/channels/1037340874172014652/1360001481893347560/1360001481893347560

