### PR TITLE
Correcting Reducer Callback Information in llms.md

### DIFF
--- a/llms.md
+++ b/llms.md
@@ -2171,8 +2171,6 @@ private handleSendMessageResult(ctx: ReducerEventContext, messageText: string) {
     switch(ctx.event.status.tag) {
     case "Committed":
         console.log(`Our message "${messageText}" sent successfully.`);
-        // ctx.event.status.value is type DatabaseUpdate
-        // which has .tables which is an array of TableUpdates
         break;
     case "Failed":
         console.error(`Failed to send "${messageText}": ${ctx.event.status.value}`);


### PR DESCRIPTION
There is currently incorrect information within the reducer callback function in `llms.txt`: 

```typescript
private handleSendMessageResult(ctx: ReducerEventContext, messageText: string) {
    const wasOurCall = ctx.reducerEvent.callerIdentity.isEqual(this.identity);
    if (!wasOurCall) return; // Only care about our own calls here

    if (ctx.reducerEvent.status === Status.Committed) {
        console.log(`Our message "${messageText}" sent successfully.`);
    } else if (ctx.reducerEvent.status.isFailed()) {
        console.error(`Failed to send "${messageText}": ${ctx.reducerEvent.status.getFailedMessage()}`);
    }
}
```

Specifically: 
- `ctx.reducerEvent.callerIdentity.isEqual(this.identity)`
- `ctx.reducerEvent.status === Status.Committed`
- `ctx.reducerEvent.status.isFailed()`
- `ctx.reducerEvent.status.getFailedMessage()`

I've corrected the issues and ensured that this particular example compiles and works by adapting it to an existing project. 