### PR TITLE
updated dotnet add package

### DIFF
--- a/docs/sdks/c-sharp/index.md
+++ b/docs/sdks/c-sharp/index.md
@@ -23,7 +23,7 @@ The SpacetimeDB client for C# contains all the tools you need to build native cl
 If you would like to create a console application using .NET, you can create a new project using `dotnet new console` and add the SpacetimeDB SDK to your dependencies:
 
 ```bash
-dotnet add package spacetimedbsdk
+dotnet add package SpacetimeDB.ClientSDK
 ```
 
 (See also the [CSharp Quickstart](/docs/modules/c-sharp/quickstart) for an in-depth example of such a console application.)

--- a/docs/sdks/c-sharp/quickstart.md
+++ b/docs/sdks/c-sharp/quickstart.md
@@ -22,7 +22,7 @@ Open the project in your IDE of choice.
 
 ## Add the NuGet package for the C# SpacetimeDB SDK
 
-Add the `SpacetimeDB.ClientSDK` [NuGet package](https://www.nuget.org/packages/spacetimedbsdk) using Visual Studio or Rider _NuGet Package Manager_ or via the .NET CLI:
+Add the `SpacetimeDB.ClientSDK` [NuGet package](https://www.nuget.org/packages/SpacetimeDB.ClientSDK/) using Visual Studio or Rider _NuGet Package Manager_ or via the .NET CLI:
 
 ```bash
 dotnet add package SpacetimeDB.ClientSDK


### PR DESCRIPTION
In the C# Client SDK project setup section, it incorrectly lists `spacetimedbsdk` as the current dotnet package in two locations: 

1. In the code block: https://github.com/clockworklabs/spacetime-docs/blob/4ebfc19ccf5d63f3feecea855be05ef620753a6a/docs/sdks/c-sharp/index.md?plain=1#L26
2. in the url: https://github.com/clockworklabs/spacetime-docs/blob/4ebfc19ccf5d63f3feecea855be05ef620753a6a/docs/sdks/c-sharp/quickstart.md?plain=1#L25

This has been updated to reflect the correct dotnet package, `SpacetimeDB.ClientSDK`. 🎉 