### PR TITLE
Fix link checking

### DIFF
--- a/docs/modules/c-sharp/index.md
+++ b/docs/modules/c-sharp/index.md
@@ -223,9 +223,9 @@ However:
 
 # Tables
 
-Tables are declared using the [`[SpacetimeDB.Table]` attribute](#table-attribute).
+Tables are declared using the `[SpacetimeDB.Table]` attribute.
 
-This macro is applied to a C# `partial class` or `partial struct` with named fields. (The `partial` modifier is required to allow code generation to add methods.) All of the fields of the table must be marked with [`[SpacetimeDB.Type]`](#type-attribute).
+This macro is applied to a C# `partial class` or `partial struct` with named fields. (The `partial` modifier is required to allow code generation to add methods.) All of the fields of the table must be marked with [`[SpacetimeDB.Type]`]( #attribute-spacetimedbtype).
 
 The resulting type is used to store rows of the table. It's a normal class (or struct). Row values are not special -- operations on row types do not, by themselves, modify the table. Instead, a [`ReducerContext`](#class-reducercontext) is needed to get a handle to the table.
 

--- a/docs/sql/index.md
+++ b/docs/sql/index.md
@@ -640,9 +640,9 @@ column
 ```
 
 
-[sdk]:       /docs/sdks/rust/index.md#subscribe-to-queries
-[http]:      /docs/http/database#databasesqlname_or_address-post
-[cli]:       /docs/cli-reference.md#spacetime-sql
+[sdk]:       /docs/sdks/rust#subscribe-to-queries
+[http]:      /docs/http/database#post-v1databasename_or_identitysql
+[cli]:       /docs/cli-reference#spacetime-sql
 
-[Identity]: /docs/index.md#identity
-[ConnectionId]:  /docs/index.md#connectionid
+[Identity]: /docs#identity
+[ConnectionId]:  /docs#connectionid

--- a/docs/webassembly-abi/index.md
+++ b/docs/webassembly-abi/index.md
@@ -493,7 +493,7 @@ uint16_t _iter_start_filtered(
 
 [`bindings_sys::raw`]: https://github.com/clockworklabs/SpacetimeDB/blob/master/crates/bindings-sys/src/lib.rs#L44-L215
 [`bindings`]: https://github.com/clockworklabs/SpacetimeDB/blob/master/crates/bindings/src/lib.rs
-[module_ref]: /docs/languages/rust/rust-module-reference
-[module_quick_start]: /docs/languages/rust/rust-module-quick-start
+[module_ref]: /docs/modules/rust
+[module_quick_start]: /docs/modules/rust/quickstart
 [wasm_c_abi]: https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md
 [c_header]: #appendix-bindingsh

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "remark-parse": "^11.0.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0"
   },
   "scripts": {
     "build": "tsc --project ./tsconfig.json",

--- a/scripts/checkLinks.ts
+++ b/scripts/checkLinks.ts
@@ -118,14 +118,8 @@ function checkLinks(): void {
         return; // Skip external links
       }
 
-      const siteLinks = ['/install', '/images', '/profile'];
-      for (const siteLink of siteLinks) {
-        if (link.startsWith(siteLink)) {
-          return; // Skip site links
-        }
-      }
-      if (link.startsWith('/#') || link == '/') {
-          return; // Skip site links
+      if (!link.startsWith('/docs')) {
+        return; // Skip site links
       }
 
       // Resolve the link

--- a/scripts/checkLinks.ts
+++ b/scripts/checkLinks.ts
@@ -118,11 +118,14 @@ function checkLinks(): void {
         return; // Skip external links
       }
 
-      const siteLinks = ['/', '/install', '/images', '/profile'];
+      const siteLinks = ['/install', '/images', '/profile'];
       for (const siteLink of siteLinks) {
-        if (link.startsWith(siteLink + '/') || link.startsWith(siteLink + '#') || link === siteLink) {
+        if (link.startsWith(siteLink)) {
           return; // Skip site links
         }
+      }
+      if (link.startsWith('/#') || link == '/') {
+          return; // Skip site links
       }
 
       // Resolve the link

--- a/scripts/checkLinks.ts
+++ b/scripts/checkLinks.ts
@@ -143,7 +143,10 @@ function checkLinks(): void {
       }
 
       // Split the resolved link into base and fragment
-      const [baseLink, fragmentRaw] = resolvedLink.split('#');
+      let [baseLink, fragmentRaw] = resolvedLink.split('#');
+      if (baseLink.endsWith('/')) {
+        baseLink = baseLink.slice(0, -1);
+      }
       const fragment: string | null = fragmentRaw || null;
 
       if (fragment) {

--- a/scripts/checkLinks.ts
+++ b/scripts/checkLinks.ts
@@ -2,6 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import nav from '../nav'; // Import the nav object directly
 import GitHubSlugger from 'github-slugger';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import { visit } from 'unist-util-visit';
 
 // Function to map slugs to file paths from nav.ts
 function extractSlugToPathMap(nav: { items: any[] }): Map<string, string> {
@@ -33,34 +36,22 @@ function validatePathsExist(slugToPath: Map<string, string>): void {
 
 // Function to extract links and images from markdown files with line numbers
 function extractLinksAndImagesFromMarkdown(filePath: string): { link: string; type: 'image' | 'link'; line: number }[] {
-  const fileContent = fs.readFileSync(filePath, 'utf-8');
-  const lines = fileContent.split('\n');
-  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g; // Matches standard Markdown links
-  const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g; // Matches image links in Markdown
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const tree = unified().use(remarkParse).parse(content);
 
-  const linksAndImages: { link: string; type: 'image' | 'link'; line: number }[] = [];
-  const imageSet = new Set<string>(); // To store links that are classified as images
+  const results: { link: string; type: 'image' | 'link'; line: number }[] = [];
 
-  lines.forEach((lineContent, index) => {
-    let match: RegExpExecArray | null;
-
-    // Extract image links and add them to the imageSet
-    while ((match = imageRegex.exec(lineContent)) !== null) {
-      const link = match[2];
-      linksAndImages.push({ link, type: 'image', line: index + 1 });
-      imageSet.add(link);
-    }
-
-    // Extract standard links
-    while ((match = linkRegex.exec(lineContent)) !== null) {
-      const link = match[2];
-      linksAndImages.push({ link, type: 'link', line: index + 1 });
+  visit(tree, ['link', 'image', 'definition'], (node: any) => {
+    const link = node.url;
+    const line = node.position?.start?.line ?? 0;
+    if (link) {
+      results.push({ link, type: node.type === 'image' ? 'image' : 'link', line });
     }
   });
 
-  // Filter out links that exist as images
-  return linksAndImages.filter(item => !(item.type === 'link' && imageSet.has(item.link)));
+  return results;
 }
+
 // Function to resolve relative links using slugs
 function resolveLink(link: string, currentSlug: string): string {
   if (link.startsWith('#')) {
@@ -101,6 +92,9 @@ function checkLinks(): void {
   // Extract valid slugs
   const validSlugs = Array.from(slugToPath.keys());
 
+  // Hacky workaround because the slug for the root is /docs/index. No other slugs have a /index at the end.
+  validSlugs.push('/docs');
+
   // Reverse map from file path to slug for current file resolution
   const pathToSlug = new Map<string, string>();
   slugToPath.forEach((filePath, slug) => {
@@ -124,9 +118,9 @@ function checkLinks(): void {
         return; // Skip external links
       }
 
-      const siteLinks = ['/install', '/images', '/profile'];
+      const siteLinks = ['/', '/install', '/images', '/profile'];
       for (const siteLink of siteLinks) {
-        if (link.startsWith(siteLink)) {
+        if (link.startsWith(siteLink + '/') || link.startsWith(siteLink + '#') || link === siteLink) {
           return; // Skip site links
         }
       }


### PR DESCRIPTION
The link checking had a few problems.

First of all, it wasn't checking "non-inline" links, i.e. where the link value itself is a "footnote" such as the ones fixed in https://github.com/clockworklabs/spacetime-docs/pull/324/files. I fixed this by using a genuine markdown parser.

Fixing revealed 9 new broken links, as well as some false positives due to the following issues:
- Links to the `/docs` root were erroneously being considered broken, because the slug is `/docs/index`
- Links to the homepage (`/`) were erroneously being considered broken, because `/` wasn't in the list of pages to skip.
- Links with trailing `/` were erroneously being considered broken, because the slugs don't end in `/`

I fixed those issues in the script, and fixed the broken links.

# Testing
- [x] Link checking detected new broken links
- [x] Output says it's still processing a ton of links, so I haven't completely broken it:
```
=== Validation Statistics ===
Total markdown files processed: 34
Total links/images processed: 879
  Valid: 117
  Invalid: 0
Total links with fragments processed: 34
  Valid links with fragments: 31
  Invalid links with fragments: 0
===============================
```