### PR TITLE
Fixed DB_NAME name mismatch

### DIFF
--- a/docs/sdks/c-sharp/quickstart.md
+++ b/docs/sdks/c-sharp/quickstart.md
@@ -141,7 +141,7 @@ To `Program.cs`, add:
 const string HOST = "http://localhost:3000";
 
 /// The database name we chose when we published our module.
-const string DBNAME = "quickstart-chat";
+const string DB_NAME = "quickstart-chat";
 
 /// Load credentials from a file and connect to the database.
 DbConnection ConnectToDB()
@@ -149,7 +149,7 @@ DbConnection ConnectToDB()
     DbConnection? conn = null;
     conn = DbConnection.Builder()
         .WithUri(HOST)
-        .WithModuleName(DBNAME)
+        .WithModuleName(DB_NAME)
         .WithToken(AuthToken.Token)
         .OnConnect(OnConnected)
         .OnConnectError(OnConnectError)


### PR DESCRIPTION
The doc text suggested DB_NAME for variable name, but code sample used DBNAME.

Changed all to DB_NAME, for consistency.

Thanks @gefjon for suggestions, on Issue #345.