### PR TITLE
Fix TypeScript Quickstart wrong import

### DIFF
--- a/docs/sdks/typescript/quickstart.md
+++ b/docs/sdks/typescript/quickstart.md
@@ -387,7 +387,7 @@ module_bindings
 With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. We've placed these in the `module_bindings` folder. The main entry to the SpacetimeDB API is the `DbConnection`, a type which manages a connection to a remote database. Let's import it and a few other types into our `client/src/App.tsx`.
 
 ```tsx
-import { DbConnection, ErrorContext, EventContext, Message, User } from './module_bindings';
+import { DbConnection, type ErrorContext, type EventContext, Message, User } from './module_bindings';
 import { Identity } from '@clockworklabs/spacetimedb-sdk';
 ```
 


### PR DESCRIPTION
This change alone doesn't fix the TypeScript Quickstart but helps.

This other PR https://github.com/clockworklabs/SpacetimeDB/pull/2747 fixes the codegen issues related to TypeScript imports too.